### PR TITLE
Change grSim_Commands to support use_angle

### DIFF
--- a/proto/grSim_Commands.proto
+++ b/proto/grSim_Commands.proto
@@ -13,6 +13,7 @@ optional float wheel3 = 11;
 optional float wheel4 = 12;
 // in radians
 optional float geneva_angle = 13;
+optional bool use_angle=14;
 }
 
 message grSim_Commands {


### PR DESCRIPTION
Change grSim_Commands to support use_angle. 
Needed for accurate robot control in grSim