### PR TITLE
Make rotate() roughly 10 times as fast. 

### DIFF
--- a/src/Vector2.cpp
+++ b/src/Vector2.cpp
@@ -6,7 +6,6 @@
 
 namespace rtt {
 
-
 Vector2::Vector2(rtt::Angle &angle, const double &length)
         :epsilon(0.00001) {
     y = sin(angle.getAngle())*length;
@@ -62,8 +61,8 @@ Vector2 Vector2::lerp(const Vector2 &other, double factor) const {
 }
 
 Vector2 Vector2::rotate(double radians) const {
-    auto c = static_cast<double>(cosl(radians));
-    auto s = static_cast<double>(sinl(radians));
+    double c = cos(radians);
+    double s = sin(radians);
     return Vector2(x*c - y*s, x*s + y*c);
 }
 
@@ -119,8 +118,8 @@ Vector2 Vector2::stretchToLength(double desiredLength) const {
     return {x*frac, y*frac};
 }
 
-double Vector2::cross(const Vector2 &other) const{
-    return this->x*other.y-this->y*other.x;
+double Vector2::cross(const Vector2 &other) const {
+    return this->x*other.y - this->y*other.x;
 }
 bool Vector2::operator==(const Vector2 &other) const {
     return fabs(this->x - other.x) < epsilon && fabs(this->y - other.y) < epsilon;


### PR DESCRIPTION
I'm quite sure this is safe enough to merge, but: this 'might' break some equality comparisons in some places (although our margin of 0.0001 should be more than enough to prevent floating point errors from taking over) if direct comparisons are being done on the double values, due to the current interpolating behavior of cosl() and sinl(). This increases the computation speed by factor 10 roughly though, as it was bottlenecking hard in AI being one of our core libraries and most important functions.  E.g. Defender computations were roughly 30% faster just by this change.

