### PR TITLE
fix timing problem

### DIFF
--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -25,7 +25,7 @@ void Timer::loop(std::function<void(void)> func, int rate) {
 
             func();
         } else {
-            std::this_thread::sleep_for((timeStep - timeDiff));
+            std::this_thread::sleep_for(std::chrono::microseconds(200));
         }
     }
 }


### PR DESCRIPTION
This PR fixes a problem with the timer class, which is used quite a lot in roboteam_ai.  I noticed that the outgoing rate was 90Hz when I actually wanted a rate of 100 Hz. After some debugging I found this issue. Apparently I have underestimated the extra delay that can be caused by sleep_for.

https://en.cppreference.com/w/cpp/thread/sleep_for
> This function may block for longer than sleep_duration due to scheduling or resource contention delays.


### The problem
In the case of 100Hz I would have a timeDiff of 10000 us (10ms) and after each function call the thread would sleep until these 10000us are full. However, it would on average add another additional 2000 us.  

### The fix
Instead of trying to be smart I just made sure the thread wakes up about 50 times as much. It is not very elegant but since there are no strict timing methods I think this is decent. with my current implementation the maximum deviation is 200 us on a tick. A 100Hz control loop now loops between 99.8 and 100 Hz instead of 89 and 100 Hz :-) 


