### PR TITLE
isOnLine() bug for cases where LineSegment is actually a Point

### DIFF
--- a/src/Line.cpp
+++ b/src/Line.cpp
@@ -71,6 +71,9 @@ Vector2 Line::project(const Vector2 &point) const {
 }
 
 bool Line::isOnLine(const Vector2 &point) const {
+    if (isPoint()){
+        return (start == point || end == point);
+    }
     Vector2 A = end - start;
     Vector2 B = point - start;
     return A.cross(B) == 0;

--- a/src/LineSegment.cpp
+++ b/src/LineSegment.cpp
@@ -173,6 +173,9 @@ Vector2 LineSegment::project(const Vector2 &point) const {
 }
 
 bool LineSegment::isOnLine(const Vector2 &point) const {
+    if (isPoint()) {
+        return start == point;
+    }
     Vector2 A = end - start;
     Vector2 B = point - start;
     double cross = A.cross(B);

--- a/test/LineTest.cpp
+++ b/test/LineTest.cpp
@@ -156,6 +156,10 @@ TEST(LineTests, pointOnLine) {
     EXPECT_TRUE(l3.isOnLine(A));
     EXPECT_TRUE(ls3.isOnLine(A));
 
+    LineSegment degenerate(point5,point5);
+    EXPECT_FALSE(degenerate.isOnLine(point6));
+    Line degenLine(degenerate);
+    EXPECT_FALSE(degenLine.isOnLine(point6));
 }
 
 TEST(LineTests, Intersections) {


### PR DESCRIPTION
The isOnLine() function behaves wrong for the case where the LineSegment is actually a point. I fixed this problem, but I expect more problems in the LineSegment for the cases where the LineSegment is actually a point. Since I am a parttimer I do not have the time to solve these problems, therefore I highly recommend someone else to look at this (I also created an issue for this). Also make sure you fix these problems in all code clones (because this functionality is cloned a lot also outside roboteam_utils, e.g. in ControlUtils on the roboteam_ai branch). Moreover take a look at Polygon, Triangle, Arcs and Circles for the cases where this things are actually points or lines and create test cases for these situations.