### PR TITLE
Added initialize call to the ctor so tactics and roles don't have to

### DIFF
--- a/include/roboteam_utils/containers/state_machine.hpp
+++ b/include/roboteam_utils/containers/state_machine.hpp
@@ -97,6 +97,9 @@ namespace rtt::collections {
              * int result = (args + ...);
              */
             (_data.emplace_back(std::make_unique<Tys>(std::forward<Tys>(args))), ...);
+
+            // Call initialize on the first element if there is an element to initialize
+            if(_data.size()) initialize();
         }
 
         /**

--- a/include/roboteam_utils/containers/state_machine.hpp
+++ b/include/roboteam_utils/containers/state_machine.hpp
@@ -99,7 +99,7 @@ namespace rtt::collections {
             (_data.emplace_back(std::make_unique<Tys>(std::forward<Tys>(args))), ...);
 
             // Call initialize on the first element if there is an element to initialize
-            if(_data.size()) initialize();
+            if (size()) initialize();
         }
 
         /**


### PR DESCRIPTION
This removes the need for the ctors of tactics and roles to explicitly call initialize() on the first tactic or skill since the state machine does it for you now!