### PR TITLE
Bug/polygon intersect

### DIFF
--- a/include/roboteam_utils/Line.h
+++ b/include/roboteam_utils/Line.h
@@ -164,6 +164,14 @@ class Line {
          */
         [[nodiscard]] std::optional<Vector2> intersects(const LineSegment &line) const ;
 
+       /**
+        * @brief Compute the line intersection of this line in positive direction, i.e. in the direction from the start to the end of the given line.
+        *
+        * @param line The line of which the positive direction intersection is computed.
+        * @return No vector if the lines do not intersect in positive direction. Otherwise it returns a vector which represents the position of intersection.
+        */
+        [[nodiscard]] std::optional<Vector2> forwardIntersect(const Line &line) const;
+
         /**
          * @brief Checks whether \ref line intersects `this`
          * 
@@ -182,6 +190,16 @@ class Line {
          */
         [[nodiscard]] bool doesIntersect(const LineSegment &line) const;
 
+    private:
+        /**
+         * Get the intersection point between this line and the given line as parameter. Moreover compute how much the given line is extended relatively in the direction of
+         * the start of the line towards the end of the line to find the intersection point.
+         *
+         * @param line Line to check against.
+         * @return std::nullopt if the lines do not intersect. Otherwise returns the intersection point and the relative extension of the given line to reach the intersection
+         * point.
+         */
+        [[nodiscard]] std::optional<std::pair<Vector2, float>> generalIntersect(const Line &line) const;
 };
 
 }

--- a/include/roboteam_utils/Line.h
+++ b/include/roboteam_utils/Line.h
@@ -14,194 +14,196 @@ class LineSegment;
  *
  */
 class Line {
-    public:
-        /**
-        * @brief Start of the line
-        *
-        */
-        Vector2 start;
-        /**
-         * @brief End of the line
-         *
-         */
-        Vector2 end;
-        /**
-         * @brief Construct a new Line object
-         * 
-         */
-        constexpr Line() = default;
+   public:
+    /**
+     * @brief Start of the line
+     *
+     */
+    Vector2 start;
+    /**
+     * @brief End of the line
+     *
+     */
+    Vector2 end;
+    /**
+     * @brief Construct a new Line object
+     *
+     */
+    constexpr Line() = default;
 
-        /**
-         * @brief Constructs a new Line object
-         * 
-         * @param _start Start of the Line
-         * @param _end End of the Line
-         * 
-         */
-        constexpr Line(const Vector2 &_start, const Vector2 &_end) noexcept
-                :start{_start}, end{_end} { } ;
-        /**
-         * @brief Constructs a new Line from a LineSegment.
-         * @param other LineSegment to use for construction
-         */
-         explicit Line(const LineSegment &other) noexcept;
-        /**
-         * @brief Gets the length of the vector representation of this line.
-         *        Note in this case it does not really make sense as this class represents lines of infinite length
-         * Literally:
-         *      (end - start).length()
-         * @return double Gets the length of the line
-         */
-        [[nodiscard]] double length() const;
+    /**
+     * @brief Constructs a new Line object
+     *
+     * @param _start Start of the Line
+     * @param _end End of the Line
+     *
+     */
+    constexpr Line(const Vector2 &_start, const Vector2 &_end) noexcept : start{_start}, end{_end} {};
+    /**
+     * @brief Constructs a new Line from a LineSegment.
+     * @param other LineSegment to use for construction
+     */
+    explicit Line(const LineSegment &other) noexcept;
+    /**
+     * @brief Gets the length of the vector representation of this line.
+     *        Note in this case it does not really make sense as this class represents lines of infinite length
+     * Literally:
+     *      (end - start).length()
+     * @return double Gets the length of the line
+     */
+    [[nodiscard]] double length() const;
 
-        /**
-         * @brief Gets the length of the vector representation of this line
-         *
-         * @return double Length of this Line
-         */
-        [[nodiscard]] double length2() const;
+    /**
+     * @brief Gets the length of the vector representation of this line
+     *
+     * @return double Length of this Line
+     */
+    [[nodiscard]] double length2() const;
 
-        /**
-         * @brief Gets the slope of this line
-         *
-         * @return double Slope of the line
-         */
-        [[nodiscard]] double slope() const;
+    /**
+     * @brief Gets the slope of this line
+     *
+     * @return double Slope of the line
+     */
+    [[nodiscard]] double slope() const;
 
-        /**
-         * @brief Gets the intercept of this line
-         * Literally:
-         *      start.y - slope() * start.x;
-         * @return double Intercept of this line
-         */
-        [[nodiscard]] double intercept() const;
+    /**
+     * @brief Gets the intercept of this line
+     * Literally:
+     *      start.y - slope() * start.x;
+     * @return double Intercept of this line
+     */
+    [[nodiscard]] double intercept() const;
 
-        /**
-         * @brief Gets the direction of the Line
-         *
-         * @return Vector2 Vector representation of the direction of this vector
-         */
-        [[nodiscard]] Vector2 direction() const;
+    /**
+     * @brief Gets the direction of the Line
+     *
+     * @return Vector2 Vector representation of the direction of this vector
+     */
+    [[nodiscard]] Vector2 direction() const;
 
-        /**
-         * @brief Gets a pair of coefficients
-         *
-         * @return std::pair<double, double> Pair of doubles where .first == slope() and .second == intercept()
-         */
-        [[nodiscard]] std::pair<double, double> coefficients() const;
+    /**
+     * @brief Gets a pair of coefficients
+     *
+     * @return std::pair<double, double> Pair of doubles where .first == slope() and .second == intercept()
+     */
+    [[nodiscard]] std::pair<double, double> coefficients() const;
 
-        /**
-         * @brief Checks whether line is vertical
-         *
-         * @return true True if line is vertical, will be true if isPoint is true
-         * @return false False if line is not vertical
-         */
-        [[nodiscard]] bool isVertical() const;
+    /**
+     * @brief Checks whether line is vertical
+     *
+     * @return true True if line is vertical, will be true if isPoint is true
+     * @return false False if line is not vertical
+     */
+    [[nodiscard]] bool isVertical() const;
 
-        /**
-         * @brief Checks whether 2 lines are parralel
-         *
-         * @param line Other line to check against
-         * @return true True if this->slope() == line.slope()
-         * @return false False if this->slope() != line.slope()
-         */
-        [[nodiscard]] bool isParallel(const Line &line) const;
-        /**
-         * @brief Checks whether 2 lines are parralel
-         *
-         * @param line Other line to check against
-         * @return true True if this->slope() == line.slope()
-         * @return false False if this->slope() != line.slope()
-         */
-        [[nodiscard]] bool isParallel(const LineSegment &line) const;
-        /**
-         * @brief Checks whether line is a single point
-         *
-         * @return true True if start == end
-         * @return false False if start != end
-         */
-        [[nodiscard]] bool isPoint() const;
-        /**
-         * @brief Gets the distance from \ref point to the line
-         * 
-         * @param point Point to get distance to
-         * @return double Distance to line
-         */
-        [[nodiscard]] double distanceToLine(const Vector2 &point) const;
+    /**
+     * @brief Checks whether 2 lines are parralel
+     *
+     * @param line Other line to check against
+     * @return true True if this->slope() == line.slope()
+     * @return false False if this->slope() != line.slope()
+     */
+    [[nodiscard]] bool isParallel(const Line &line) const;
+    /**
+     * @brief Checks whether 2 lines are parralel
+     *
+     * @param line Other line to check against
+     * @return true True if this->slope() == line.slope()
+     * @return false False if this->slope() != line.slope()
+     */
+    [[nodiscard]] bool isParallel(const LineSegment &line) const;
+    /**
+     * @brief Checks whether line is a single point
+     *
+     * @return true True if start == end
+     * @return false False if start != end
+     */
+    [[nodiscard]] bool isPoint() const;
+    /**
+     * @brief Gets the distance from \ref point to the line
+     *
+     * @param point Point to get distance to
+     * @return double Distance to line
+     */
+    [[nodiscard]] double distanceToLine(const Vector2 &point) const;
 
-        /**
-         * @brief Checks whether a \ref point is on the line
-         * 
-         * @param point Point to check `this` against
-         * @return true If \ref point is on `this`
-         * @return false If \ref point is not on `this`
-         */
-        [[nodiscard]] bool isOnLine(const Vector2 &point) const;
+    /**
+     * @brief Checks whether a \ref point is on the line
+     *
+     * @param point Point to check `this` against
+     * @return true If \ref point is on `this`
+     * @return false If \ref point is not on `this`
+     */
+    [[nodiscard]] bool isOnLine(const Vector2 &point) const;
 
-        /**
-         * @brief Projects the point onto the line
-         * 
-         * @param point Point to get the projection to
-         * @return Vector2 Vector projection from the line to the point
-         */
-        [[nodiscard]] Vector2 project(const Vector2 &point) const;
+    /**
+     * @brief Projects the point onto the line
+     *
+     * @param point Point to get the projection to
+     * @return Vector2 Vector projection from the line to the point
+     */
+    [[nodiscard]] Vector2 project(const Vector2 &point) const;
 
-        /**
-         * @brief Gets the intersection of the lines
-         * See https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection for help
-         * 
-         * @param line Line to get an intersection from
-         * @return std::shared_ptr<Vector2> Vector representation of this intersection
-         */
-        [[nodiscard]] std::optional<Vector2> intersects(const Line &line) const;
+    /**
+     * @brief Gets the intersection of the lines
+     * See https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection for help
+     *
+     * @param line Line to get an intersection from
+     * @return std::shared_ptr<Vector2> Vector representation of this intersection
+     */
+    [[nodiscard]] std::optional<Vector2> intersects(const Line &line) const;
 
-        /**
-         * @brief Gets the intersection of the lines
-         * See https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection for help
-         * 
-         * @param line LineSegment to get an intersection from
-         * @return std::shared_ptr<Vector2> Vector representation of this intersection
-         */
-        [[nodiscard]] std::optional<Vector2> intersects(const LineSegment &line) const ;
+    /**
+     * @brief Gets the intersection of the lines
+     * See https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection for help
+     *
+     * @param line LineSegment to get an intersection from
+     * @return std::shared_ptr<Vector2> Vector representation of this intersection
+     */
+    [[nodiscard]] std::optional<Vector2> intersects(const LineSegment &line) const;
 
-       /**
-        * @brief Compute the line intersection of this line in positive direction, i.e. in the direction from the start to the end of the given line.
-        *
-        * @param line The line of which the positive direction intersection is computed.
-        * @return No vector if the lines do not intersect in positive direction. Otherwise it returns a vector which represents the position of intersection.
-        */
-        [[nodiscard]] std::optional<Vector2> forwardIntersect(const Line &line) const;
+    /**
+     * @brief Compute the line intersection of this line and the given as parameter line in positive direction.
+     * Which means in the direction from the start to the end of the given parameter line. The intersection position does not have to be in positive direction compared to this
+     * line, only to the given parameter line. Note if the line given as parameter is equal to this line then no intersection is returned.
+     *
+     * @param line The line of which the positive direction intersection is computed.
+     * @return No vector if the lines do not intersect in positive direction. Otherwise it returns a vector which represents the position of intersection.
+     */
+    [[nodiscard]] std::optional<Vector2> forwardIntersect(const Line &line) const;
 
-        /**
-         * @brief Checks whether \ref line intersects `this`
-         * 
-         * @param line Line to check against
-         * @return true if \ref line intersects `this`
-         * @return false False if \ref line does not intersect `this`
-         */
-        [[nodiscard]] bool doesIntersect(const Line &line) const;
+    /**
+     * @brief Checks whether \ref line intersects `this`
+     *
+     * @param line Line to check against
+     * @return true if \ref line intersects `this`
+     * @return false False if \ref line does not intersect `this`
+     */
+    [[nodiscard]] bool doesIntersect(const Line &line) const;
 
-        /**
-         * @brief Checks whether \ref line intersects `this`
-         * 
-         * @param line Line to check against
-         * @return true True if \ref line intersects `this`
-         * @return false False if \ref line does not intersect `this`
-         */
-        [[nodiscard]] bool doesIntersect(const LineSegment &line) const;
+    /**
+     * @brief Checks whether \ref line intersects `this`
+     *
+     * @param line Line to check against
+     * @return true True if \ref line intersects `this`
+     * @return false False if \ref line does not intersect `this`
+     */
+    [[nodiscard]] bool doesIntersect(const LineSegment &line) const;
 
-    private:
-        /**
-         * Get the intersection point between this line and the given line as parameter. Moreover compute how much the given line is extended relatively in the direction of
-         * the start of the line towards the end of the line to find the intersection point.
-         *
-         * @param line Line to check against.
-         * @return std::nullopt if the lines do not intersect. Otherwise returns the intersection point and the relative extension of the given line to reach the intersection
-         * point.
-         */
-        [[nodiscard]] std::optional<std::pair<Vector2, float>> generalIntersect(const Line &line) const;
+   private:
+    /**
+     * Get the intersection point between this line and the given line as parameter. Moreover compute how much the given line is extended relatively in the direction of
+     * the start of the line towards the end of the line to find the intersection point. Note if the line given as parameter is equal to this line then no intersection is
+     * returned.
+     *
+     * @param line Line to check against.
+     * @return std::nullopt if the lines do not intersect. Otherwise returns the intersection point and the relative extension of the given line to reach the intersection
+     * point.
+     */
+    [[nodiscard]] std::optional<std::pair<Vector2, float>> generalIntersect(const Line &line) const;
 };
 
-}
+}  // namespace rtt
 
-#endif //ROBOTEAM_UTILS_LINE_H
+#endif  // ROBOTEAM_UTILS_LINE_H

--- a/include/roboteam_utils/Line.h
+++ b/include/roboteam_utils/Line.h
@@ -164,9 +164,8 @@ class Line {
     [[nodiscard]] std::optional<Vector2> intersects(const LineSegment &line) const;
 
     /**
-     * @brief Compute the line intersection of this line and the given as parameter line in positive direction.
-     * Which means in the direction from the start to the end of the given parameter line. The intersection position does not have to be in positive direction compared to this
-     * line, only to the given parameter line. Note if the line given as parameter is equal to this line then no intersection is returned.
+     * @brief Compute the intersection of this, and the line given as parameter. The parameter line is treated as half-line, so for a line a + tb, with b the direction vector and
+     * a the start parameter of this line, any point on the line where t<0 is not included in the calculation of the intersection.
      *
      * @param line The line of which the positive direction intersection is computed.
      * @return No vector if the lines do not intersect in positive direction. Otherwise it returns a vector which represents the position of intersection.

--- a/include/roboteam_utils/LineSegment.h
+++ b/include/roboteam_utils/LineSegment.h
@@ -220,7 +220,8 @@ class LineSegment {
     [[nodiscard]] std::optional<LineSegment> shadow(const Vector2 &source, const LineSegment &obstacle, float negligible_shadow_length = 1e-6) const;
 
     /**
-     * Checks if two LineSegments are actually the same, i.e. to check if the ending of the LineSegments are at the same locations
+     * Checks if two LineSegments are actually the same, i.e. to check if the ending of the LineSegments are at the same locations. Note that the directionns of the lines might be
+     * different in case of equality.
      * @param other The other LineSegment to which comparisons are made.
      * @return True if the LineSegments are the same, false otherwise.
      */

--- a/include/roboteam_utils/LineSegment.h
+++ b/include/roboteam_utils/LineSegment.h
@@ -12,220 +12,225 @@ class Line;
  *
  */
 class LineSegment {
-    public:
-        /**
-         * @brief Constructs a new LineSegment
-         *
-         */
-        constexpr LineSegment() = default;
+   public:
+    /**
+     * @brief Constructs a new LineSegment
+     *
+     */
+    constexpr LineSegment() = default;
 
-        /**
-         * @brief Constructs a LineSegment
-         *
-         * @param _start Start of the Line
-         * @param _end End of the Line
-         *
-         */
-        constexpr LineSegment(const Vector2 &_start, const Vector2 &_end)
-                :start{_start}, end{_end} { };
-        /**
-         * @brief Construct a LineSegment from a line.
-         * @param line Line to construct LineSegment from
-         */
-        explicit LineSegment(const Line &line);
-        /**
-         * @brief Start of the line
-         */
-        Vector2 start;
+    /**
+     * @brief Constructs a LineSegment
+     *
+     * @param _start Start of the Line
+     * @param _end End of the Line
+     *
+     */
+    constexpr LineSegment(const Vector2 &_start, const Vector2 &_end) : start{_start}, end{_end} {};
+    /**
+     * @brief Construct a LineSegment from a line.
+     * @param line Line to construct LineSegment from
+     */
+    explicit LineSegment(const Line &line);
+    /**
+     * @brief Start of the line
+     */
+    Vector2 start;
 
-        /**
-         * @brief End of the line
-         *
-         */
-        Vector2 end;
+    /**
+     * @brief End of the line
+     *
+     */
+    Vector2 end;
 
-        /**
-         * @brief Gets the length of the vector representation of this line
-         * Literally:
-         *      (end - start).length()
-         * @return double Gets the length of the line
-         */
-        [[nodiscard]] double length() const;
+    /**
+     * @brief Gets the length of the vector representation of this line
+     * Literally:
+     *      (end - start).length()
+     * @return double Gets the length of the line
+     */
+    [[nodiscard]] double length() const;
 
-        /**
-         * @brief Gets the length of the vector representation of this line
-         *
-         * @return double Length of this Line
-         */
-        [[nodiscard]] double length2() const;
+    /**
+     * @brief Gets the length of the vector representation of this line
+     *
+     * @return double Length of this Line
+     */
+    [[nodiscard]] double length2() const;
 
-        /**
-         * @brief Gets the slope of this line
-         *
-         * @return double Slope of the line
-         */
-        [[nodiscard]] double slope() const;
+    /**
+     * @brief Gets the slope of this line
+     *
+     * @return double Slope of the line
+     */
+    [[nodiscard]] double slope() const;
 
-        /**
-         * @brief Gets the intercept of this line
-         * Literally:
-         *      start.y - slope() * start.x;
-         * @return double Intercept of this line
-         */
-        [[nodiscard]] double intercept() const;
+    /**
+     * @brief Gets the intercept of this line
+     * Literally:
+     *      start.y - slope() * start.x;
+     * @return double Intercept of this line
+     */
+    [[nodiscard]] double intercept() const;
 
-        /**
-         * @brief Gets the direction of the Line
-         *
-         * @return Vector2 Vector representation of the direction of this vector
-         */
-        [[nodiscard]] Vector2 direction() const;
+    /**
+     * @brief Gets the direction of the Line
+     *
+     * @return Vector2 Vector representation of the direction of this vector
+     */
+    [[nodiscard]] Vector2 direction() const;
 
-        /**
-         * @brief Gets a pair of coefficients
-         *
-         * @return std::pair<double, double> Pair of doubles where .first == slope() and .second == intercept()
-         */
-        [[nodiscard]] std::pair<double, double> coefficients() const;
+    /**
+     * @brief Gets a pair of coefficients
+     *
+     * @return std::pair<double, double> Pair of doubles where .first == slope() and .second == intercept()
+     */
+    [[nodiscard]] std::pair<double, double> coefficients() const;
 
-        /**
-         * @brief Checks whether line is vertical
-         *
-         * @return true True if line is vertical, will be true if isPoint is true
-         * @return false False if line is not vertical
-         */
-        [[nodiscard]] bool isVertical() const;
+    /**
+     * @brief Checks whether line is vertical
+     *
+     * @return true True if line is vertical, will be true if isPoint is true
+     * @return false False if line is not vertical
+     */
+    [[nodiscard]] bool isVertical() const;
 
-        /**
-         * @brief Checks whether 2 lines are parallel
-         *
-         * @param line Other line to check against
-         * @return true True if this->slope() == line.slope()
-         * @return false False if this->slope() != line.slope()
-         */
-        [[nodiscard]] bool isParallel(const Line &line) const;
-        /**
-         * @brief Checks whether 2 lines are parallel
-         *
-         * @param line Other line to check against
-         * @return true True if this->slope() == line.slope()
-         * @return false False if this->slope() != line.slope()
-         */
-        [[nodiscard]] bool isParallel(const LineSegment &line) const;
-        /**
-         * @brief Checks whether line is a single point
-         *
-         * @return true True if start == end
-         * @return false False if start != end
-         */
-        [[nodiscard]] bool isPoint() const;
+    /**
+     * @brief Checks whether 2 lines are parallel
+     *
+     * @param line Other line to check against
+     * @return true True if this->slope() == line.slope()
+     * @return false False if this->slope() != line.slope()
+     */
+    [[nodiscard]] bool isParallel(const Line &line) const;
+    /**
+     * @brief Checks whether 2 lines are parallel
+     *
+     * @param line Other line to check against
+     * @return true True if this->slope() == line.slope()
+     * @return false False if this->slope() != line.slope()
+     */
+    [[nodiscard]] bool isParallel(const LineSegment &line) const;
+    /**
+     * @brief Checks whether line is a single point
+     *
+     * @return true True if start == end
+     * @return false False if start != end
+     */
+    [[nodiscard]] bool isPoint() const;
 
-        /**
-         * @brief Gets the distance from the line to a point
-         *
-         * @param point Point to get distance to
-         * @return double distance between line and point
-         */
-        [[nodiscard]] double distanceToLine(const Vector2 &point) const;
-        /**
-         * @brief Gets the shortest distance between any two points on both line segments
-         * @param point Point to get distance to
-         * @return distance between this line and the passed line.
-         */
-        [[nodiscard]] double distanceToLine(const LineSegment &line) const;
-        /**
-         * @brief Checks whether a point is on the line
-         *
-         * @param point Point to check
-         * @return true True if the point is on this line
-         * @return false False if the point is not on this line
-         */
-        [[nodiscard]] bool isOnLine(const Vector2 &point) const;
+    /**
+     * @brief Gets the distance from the line to a point
+     *
+     * @param point Point to get distance to
+     * @return double distance between line and point
+     */
+    [[nodiscard]] double distanceToLine(const Vector2 &point) const;
+    /**
+     * @brief Gets the shortest distance between any two points on both line segments
+     * @param point Point to get distance to
+     * @return distance between this line and the passed line.
+     */
+    [[nodiscard]] double distanceToLine(const LineSegment &line) const;
+    /**
+     * @brief Checks whether a point is on the line
+     *
+     * @param point Point to check
+     * @return true True if the point is on this line
+     * @return false False if the point is not on this line
+     */
+    [[nodiscard]] bool isOnLine(const Vector2 &point) const;
 
-        /**
-         * @brief Gets the projection of \ref point to `this`
-         * 
-         * @param point Point to project
-         * @return Vector2 Vector representation of this projectoin
-         */
-        [[nodiscard]] Vector2 project(const Vector2 &point) const;
+    /**
+     * @brief Gets the projection of \ref point to `this`
+     *
+     * @param point Point to project
+     * @return Vector2 Vector representation of this projectoin
+     */
+    [[nodiscard]] Vector2 project(const Vector2 &point) const;
 
-        /**
-         * @brief Gets the intersection of the lines
-         * See https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection for help
-         * 
-         * @param line Line to get an intersection from
-         * @return std::shared_ptr<Vector2> Vector representation of this intersection
-         */
-        [[nodiscard]] std::optional<Vector2> intersects(const Line &line) const;
+    /**
+     * @brief Gets the intersection of the lines
+     * See https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection for help
+     *
+     * @param line Line to get an intersection from
+     * @return std::shared_ptr<Vector2> Vector representation of this intersection
+     */
+    [[nodiscard]] std::optional<Vector2> intersects(const Line &line) const;
 
-        /**
-         * @brief Gets the intersection of the lines
-         * See https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection for help
-         * 
-         * @param line LineSegment to get an intersection from
-         * @return std::shared_ptr<Vector2> Vector representation of this intersection
-         */
-        [[nodiscard]] std::optional<Vector2> intersects(const LineSegment &line) const;
+    /**
+     * @brief Gets the intersection of the lines
+     * See https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection for help
+     *
+     * @param line LineSegment to get an intersection from
+     * @return std::shared_ptr<Vector2> Vector representation of this intersection
+     */
+    [[nodiscard]] std::optional<Vector2> intersects(const LineSegment &line) const;
 
-        /**
-         * @brief Checks whether \ref line intersects `this`
-         * 
-         * @param line Line to check against
-         * @return true if \ref line intersects `this`
-         * @return false False if \ref line does not intersect `this`
-         */
-        [[nodiscard]] bool doesIntersect(const Line &line) const;
+    /**
+     * @brief Checks whether \ref line intersects `this`
+     *
+     * @param line Line to check against
+     * @return true if \ref line intersects `this`
+     * @return false False if \ref line does not intersect `this`
+     */
+    [[nodiscard]] bool doesIntersect(const Line &line) const;
 
-        /**
-         * @brief Checks whether \ref line intersects `this`
-         * 
-         * @param line Line to check against
-         * @return true True if \ref line intersects `this`
-         * @return false False if \ref line does not intersect `this`
-         */
-        [[nodiscard]] bool doesIntersect(const LineSegment &line) const;
+    /**
+     * @brief Checks whether \ref line intersects `this`
+     *
+     * @param line Line to check against
+     * @return true True if \ref line intersects `this`
+     * @return false False if \ref line does not intersect `this`
+     */
+    [[nodiscard]] bool doesIntersect(const LineSegment &line) const;
 
-        /**
-         * @brief Same as normal intersect, but always returns false if the lines are parallel
-         * intersection points of non-parallel lines are called non-simple (hence the name)
-         *
-         * @param line Line to check against
-         * @return true True if \ref line intersects `this`
-         * @return false False if \ref `line` does not intersect `this`
-         */
-        [[nodiscard]] bool nonSimpleDoesIntersect(const LineSegment &line) const;
+    /**
+     * @brief Same as normal intersect, but always returns false if the lines are parallel
+     * intersection points of non-parallel lines are called non-simple (hence the name)
+     *
+     * @param line Line to check against
+     * @return true True if \ref line intersects `this`
+     * @return false False if \ref `line` does not intersect `this`
+     */
+    [[nodiscard]] bool nonSimpleDoesIntersect(const LineSegment &line) const;
 
-        /**
-         * @brief Gets a vector representation of an intersection
-         *
-         * same as normal intersect, but always returns false if the lines are parallel
-         * intersection points of non-parallel lines are called non-simple (hence the name)
-         *
-         * @param line Line to check against
-         * @return std::shared_ptr<Vector2> Returns a shared_ptr to a Vector2 that represents the intersection
-         */
-        [[nodiscard]] std::optional<Vector2> nonSimpleIntersects(const LineSegment &line) const;
+    /**
+     * @brief Gets a vector representation of an intersection
+     *
+     * same as normal intersect, but always returns false if the lines are parallel
+     * intersection points of non-parallel lines are called non-simple (hence the name)
+     *
+     * @param line Line to check against
+     * @return std::shared_ptr<Vector2> Returns a shared_ptr to a Vector2 that represents the intersection
+     */
+    [[nodiscard]] std::optional<Vector2> nonSimpleIntersects(const LineSegment &line) const;
 
-        /**
-         * @brief Computes the shadow caused by an obstacle (LineSegment) and light source on this LineSegment.
-         * The shadow is a part of this LineSegment. And something is considered to be in the shadow if the line between the source and the position on the line intersects with
-         * the obstacle LineSegment (so if the source is on the obstacle LineSegment then everything is in the shadow).
-         *
-         * @param source The place where the 'light source' is located, i.d. the position from which the projected shadow is computed.
-         * @param obstacle The obstacle LineSegment which blocks the 'lights' and therefore might cause a shadow on this LineSegment.
-         * @param negligible_shadow_length If the length of the shadow is smaller than this value then there is no shadow (if not set then the negligible shadow length is 1e-6).
-         * @return No Linesegment if there is no shadow or if the shadow is smaller than the negligible length. Otherwise return the Linesegment that represents the shadow on this
-         * LineSegment.
-         */
-        [[nodiscard]] std::optional<LineSegment> shadow(const Vector2 &source, const LineSegment &obstacle, float negligible_shadow_length = 1e-6) const;
+    /**
+     * @brief Computes the shadow caused by an obstacle (LineSegment) and light source on this LineSegment.
+     * The shadow is a part of this LineSegment. And something is considered to be in the shadow if the line between the source and the position on the line intersects with
+     * the obstacle LineSegment (so if the source is on the obstacle LineSegment then everything is in the shadow).
+     *
+     * @param source The place where the 'light source' is located, i.d. the position from which the projected shadow is computed.
+     * @param obstacle The obstacle LineSegment which blocks the 'lights' and therefore might cause a shadow on this LineSegment.
+     * @param negligible_shadow_length If the length of the shadow is smaller than this value then there is no shadow (if not set then the negligible shadow length is 1e-6).
+     * @return No Linesegment if there is no shadow or if the shadow is smaller than the negligible length. Otherwise return the Linesegment that represents the shadow on this
+     * LineSegment.
+     */
+    [[nodiscard]] std::optional<LineSegment> shadow(const Vector2 &source, const LineSegment &obstacle, float negligible_shadow_length = 1e-6) const;
 
-        /**
-         * @brief Destroy the Line Segment object
-         * 
-         */
-        virtual ~LineSegment() = default;
+    /**
+     * Checks if two LineSegments are actually the same, i.e. to check if they have the same end points.
+     * @param other The other LineSegment to which comparisons are made.
+     * @return True if the LineSegments are the same, false otherwise.
+     */
+    [[nodiscard]] bool operator==(const LineSegment &other) const;
 
+    /**
+     * @brief Destroy the Line Segment object
+     *
+     */
+    virtual ~LineSegment() = default;
 };
-}
-#endif //ROBOTEAM_UTILS_LINESEGMENT_H
+}  // namespace rtt
+#endif  // ROBOTEAM_UTILS_LINESEGMENT_H

--- a/include/roboteam_utils/LineSegment.h
+++ b/include/roboteam_utils/LineSegment.h
@@ -220,7 +220,7 @@ class LineSegment {
     [[nodiscard]] std::optional<LineSegment> shadow(const Vector2 &source, const LineSegment &obstacle, float negligible_shadow_length = 1e-6) const;
 
     /**
-     * Checks if two LineSegments are actually the same, i.e. to check if they have the same end points.
+     * Checks if two LineSegments are actually the same, i.e. to check if the ending of the LineSegments are at the same locations
      * @param other The other LineSegment to which comparisons are made.
      * @return True if the LineSegments are the same, false otherwise.
      */

--- a/include/roboteam_utils/LineSegment.h
+++ b/include/roboteam_utils/LineSegment.h
@@ -208,6 +208,19 @@ class LineSegment {
         [[nodiscard]] std::optional<Vector2> nonSimpleIntersects(const LineSegment &line) const;
 
         /**
+         * @brief Computes the shadow caused by an obstacle (LineSegment) and light source on this LineSegment.
+         * The shadow is a part of this LineSegment. And something is considered to be in the shadow if the line between the source and the position on the line intersects with
+         * the obstacle LineSegment (so if the source is on the obstacle LineSegment then everything is in the shadow).
+         *
+         * @param source The place where the 'light source' is located, i.d. the position from which the projected shadow is computed.
+         * @param obstacle The obstacle LineSegment which blocks the 'lights' and therefore might cause a shadow on this LineSegment.
+         * @param negligible_shadow_length If the length of the shadow is smaller than this value then there is no shadow (if not set then the negligible shadow length is 1e-6).
+         * @return No Linesegment if there is no shadow or if the shadow is smaller than the negligible length. Otherwise return the Linesegment that represents the shadow on this
+         * LineSegment.
+         */
+        [[nodiscard]] std::optional<LineSegment> shadow(const Vector2 &source, const LineSegment &obstacle, float negligible_shadow_length = 1e-6) const;
+
+        /**
          * @brief Destroy the Line Segment object
          * 
          */

--- a/include/roboteam_utils/LineSegment.h
+++ b/include/roboteam_utils/LineSegment.h
@@ -196,15 +196,17 @@ class LineSegment {
     [[nodiscard]] bool nonSimpleDoesIntersect(const LineSegment &line) const;
 
     /**
-     * @brief Gets a vector representation of an intersection
+     * @brief Return the intersection(s) of two LineSegments.
      *
-     * same as normal intersect, but always returns false if the lines are parallel
-     * intersection points of non-parallel lines are called non-simple (hence the name)
+     * This is the only correct implementation of intersects that works for every case, e.g. parallel lines and LineSegments that are actually points. In case:
+     * - The LineSegments do not intersect, it returns an empty set.
+     * - The LineSegments do only intersect once, it returns a set with the intersection location as Vector2.
+     * - The intersection of these LineSegments is a LineSegment L, then it returns the start and end points of this LineSegment L.
      *
-     * @param line Line to check against
-     * @return std::shared_ptr<Vector2> Returns a shared_ptr to a Vector2 that represents the intersection
+     * @param line Line to check against.
+     * @return std::set<Vector2> Returns a set of the intersections (Vector2).
      */
-    [[nodiscard]] std::optional<Vector2> nonSimpleIntersects(const LineSegment &line) const;
+    [[nodiscard]] std::vector<Vector2> correctIntersects(const LineSegment &line) const;
 
     /**
      * @brief Computes the shadow caused by an obstacle (LineSegment) and light source on this LineSegment.

--- a/include/roboteam_utils/Polygon.h
+++ b/include/roboteam_utils/Polygon.h
@@ -7,6 +7,7 @@
 
 #include "Vector2.h"
 #include "LineSegment.h"
+#include <algorithm>
 #include <iostream>
 #include <vector>
 

--- a/src/Line.cpp
+++ b/src/Line.cpp
@@ -78,42 +78,47 @@ bool Line::isOnLine(const Vector2 &point) const {
 
 // see https://en.wikipedia.org/wiki/Line%E2%80%93line_intersection for help. These should be thoroughly tested
 std::optional<Vector2> Line::intersects(const Line &line) const {
-    Vector2 A = start - end;
-    Vector2 B = line.start - line.end;
-    double denom = A.cross(B);
-    if (denom != 0) {
-        Vector2 C = start - line.start;
-        double numer = - C.cross(B);
-        double t = numer/denom;
-        return start + A*t;
+    auto result = generalIntersect(Line(line));
+    return result.has_value() ? std::optional(result.value().first) : std::nullopt;
+}
+
+std::optional<Vector2> Line::intersects(const LineSegment &line) const {
+    auto result = generalIntersect(Line(line));
+    if (result.has_value()) {
+        float u = result.value().second;
+        if (u >= 0 && u <= 1) return std::optional(result.value().first);
     }
     return std::nullopt;
 }
 
-std::optional<Vector2> Line::intersects(const LineSegment &line) const {
+std::optional<Vector2> Line::forwardIntersect(const Line &line) const {
+    auto result = generalIntersect(Line(line));
+    if (result.has_value()) {
+        float u = result.value().second;
+        if (u >= 0) return std::optional(result.value().first);
+    }
+    return std::nullopt;
+}
+
+bool Line::doesIntersect(const Line &line) const {
+    return !this->isParallel(line);
+}
+
+bool Line::doesIntersect(const LineSegment &line) const {
+    return intersects(line).has_value();
+}
+
+std::optional<std::pair<Vector2, float>> Line::generalIntersect(const Line &line) const {
     Vector2 A = start - end;
     Vector2 B = line.start - line.end;
     double denom = A.cross(B);
     if (denom != 0) {
         Vector2 C = start - line.start;
         double numer = C.cross(A);
-        double u = numer/denom;
-        if (! (u < 0 || u > 1)) {
-            return line.start - B*u;
-        }
+        double u = numer / denom;
+        return std::pair(line.start - B*u, u);
     }
     return std::nullopt;
-}
-
-bool Line::doesIntersect(const Line &line) const {
-    return ! this->isParallel(line);
-}
-
-bool Line::doesIntersect(const LineSegment &line) const {
-    if (intersects(line)) {
-        return true;
-    }
-    return false;
 }
 
 }

--- a/src/LineSegment.cpp
+++ b/src/LineSegment.cpp
@@ -174,7 +174,7 @@ Vector2 LineSegment::project(const Vector2 &point) const {
 
 bool LineSegment::isOnLine(const Vector2 &point) const {
     if (isPoint()) {
-        return start == point;
+        return (start == point || end == point);
     }
     Vector2 A = end - start;
     Vector2 B = point - start;

--- a/src/LineSegment.cpp
+++ b/src/LineSegment.cpp
@@ -283,8 +283,8 @@ std::optional<LineSegment> LineSegment::shadow(const Vector2 &source, const Line
     } else if (isPoint()) {
         return std::nullopt;
     }
-    std::optional<Vector2> firstIntersect = Line(source, obstacle.start).forwardIntersect(Line(*this));
-    std::optional<Vector2> secondIntersect = Line(source, obstacle.end).forwardIntersect(Line(*this));
+    std::optional<Vector2> firstIntersect = Line(*this).forwardIntersect(Line(source, obstacle.start));
+    std::optional<Vector2> secondIntersect = Line(*this).forwardIntersect(Line(source, obstacle.end));
     if (!firstIntersect.has_value() && !secondIntersect.has_value()) {
         return std::nullopt;
     }
@@ -303,4 +303,13 @@ std::optional<LineSegment> LineSegment::shadow(const Vector2 &source, const Line
     return shadow.length() > negligible_shadow_length ? std::optional(shadow) : std::nullopt;
 }
 
+bool LineSegment::operator==(const LineSegment &other) const {
+    if (start == other.start && end == other.end) {
+        return true;
+    } else if (start == other.end && end == other.start) {
+        return true;
+    } else {
+        return false;
+    }
+}
 }

--- a/src/LineSegment.cpp
+++ b/src/LineSegment.cpp
@@ -277,21 +277,29 @@ double LineSegment::distanceToLine(const LineSegment &line) const {
 }
 
 std::optional<LineSegment> LineSegment::shadow(const Vector2 &source, const LineSegment &obstacle, float negligible_shadow_length) const {
-    // If the source is on the obstacle line then the entire line is in the shadow, because every line from the source intersects with the obstacle line.
     if (obstacle.isOnLine(source)) {
+        // If the source is on the obstacle line then the entire line is in the shadow, because every line from the source intersects with the obstacle line.
         return length() > negligible_shadow_length ? std::optional(*this) : std::nullopt;
     } else if (isPoint()) {
+        /* If the projection LineSegment is a point then there is no shadow on this LineSegment. This case is needed, because a point cannot be changed into an infinite line,
+         * since the direction of a point is not known. */
         return std::nullopt;
     }
     std::optional<Vector2> firstIntersect = Line(*this).forwardIntersect(Line(source, obstacle.start));
     std::optional<Vector2> secondIntersect = Line(*this).forwardIntersect(Line(source, obstacle.end));
     if (!firstIntersect.has_value() && !secondIntersect.has_value()) {
+        // If both lines from the sources to the start and end of the obstacle do not intersect with the infinite line expansion of this projection line then there is no shadow.
         return std::nullopt;
     }
     LineSegment shadow;
     if (firstIntersect.has_value() && secondIntersect.has_value()) {
+        /* If they do intersect then we can compute the shadow by projecting points in the infinite expansion of the LineSegments to either endings of the LineSegment (note
+         * projection does not change the intersection location if the location is already at the LineSegment). */
         shadow = LineSegment(project(firstIntersect.value()), project(secondIntersect.value()));
     } else {
+        /* If there is only one intersection then the shadow is unbounded in one direction. By only checking if the ending furthest away from the intersection point is visible you
+        know for all cases (both for the cases where the intersection point is outside the LineSegment and at the LineSegment) where the shadow is. Moreover you do this quite
+        efficiently, because you only have to check for one LienSegment whether it intersects with the obstacle. */
         Vector2 onlyIntersection = project(firstIntersect.has_value() ? firstIntersect.value() : secondIntersect.value());
         double distanceIntersectionToStart = (start - onlyIntersection).length();
         double distanceIntersectionToEnd = (end - onlyIntersection).length();
@@ -304,12 +312,6 @@ std::optional<LineSegment> LineSegment::shadow(const Vector2 &source, const Line
 }
 
 bool LineSegment::operator==(const LineSegment &other) const {
-    if (start == other.start && end == other.end) {
-        return true;
-    } else if (start == other.end && end == other.start) {
-        return true;
-    } else {
-        return false;
-    }
+    return ((start == other.start && end == other.end) || (start == other.end && end == other.start));
 }
 }

--- a/src/LineSegment.cpp
+++ b/src/LineSegment.cpp
@@ -277,6 +277,8 @@ std::optional<LineSegment> LineSegment::shadow(const Vector2 &source, const Line
     // If the source is on the obstacle line then the entire line is in the shadow, because every line from the source intersects with the obstacle line.
     if (obstacle.isOnLine(source)) {
         return length() > negligible_shadow_length ? std::optional(*this) : std::nullopt;
+    } else if (isPoint()) {
+        return std::nullopt;
     }
     std::optional<Vector2> firstIntersect = Line(source, obstacle.start).forwardIntersect(Line(*this));
     std::optional<Vector2> secondIntersect = Line(source, obstacle.end).forwardIntersect(Line(*this));

--- a/src/Polygon.cpp
+++ b/src/Polygon.cpp
@@ -6,8 +6,8 @@
 #include <numeric>
 
 namespace rtt {
-///constructor for rectangles oriented straight with respect to the x-axis.
-    Polygon::Polygon(const Vector2 &lowerLeftCorner, double xlen, double ylen) 
+    ///constructor for rectangles oriented straight with respect to the x-axis.
+    Polygon::Polygon(const Vector2 &lowerLeftCorner, double xlen, double ylen)
         : vertices {
             lowerLeftCorner,
             Vector2{ lowerLeftCorner.x + xlen, lowerLeftCorner.y },
@@ -59,8 +59,8 @@ namespace rtt {
         return totalLength;
     }
 
-//https://stackoverflow.com/questions/471962/how-do-i-efficiently-determine-if-a-polygon-is-convex-non-convex-or-complex
-// this function only works if your polygon is already simple. In 90% of the cases when a polygon is not simple, it will not be convex
+    //https://stackoverflow.com/questions/471962/how-do-i-efficiently-determine-if-a-polygon-is-convex-non-convex-or-complex
+    // this function only works if your polygon is already simple. In 90% of the cases when a polygon is not simple, it will not be convex
     bool Polygon::isConvex() const {
         if (amountOfVertices() < 4) 
             return true;// triangles are always convex
@@ -84,9 +84,9 @@ namespace rtt {
         return true;
     }
 
-// there are multiple possible algorithms, see
-//https://www.quora.com/What-is-the-simplest-algorithm-to-know-if-a-polygon-is-simple-or-not
-// this is the 'naive' O(N^2) approach which is fine for small cases (polygons with less than say 8-10 vertices)
+    // there are multiple possible algorithms, see
+    //https://www.quora.com/What-is-the-simplest-algorithm-to-know-if-a-polygon-is-simple-or-not
+    // this is the 'naive' O(N^2) approach which is fine for small cases (polygons with less than say 8-10 vertices)
     bool Polygon::isSimple() const {
         // we loop over every unique pair
         std::vector<LineSegment> lines{ };
@@ -107,9 +107,9 @@ namespace rtt {
         return true;
     }
 
-//https://wrf.ecse.rpi.edu/Research/Short_Notes/pnpoly.html
-// this is black magic but if it works it works
-/// on the boundary this function does not work!! see documentation if you are interested
+    //https://wrf.ecse.rpi.edu/Research/Short_Notes/pnpoly.html
+    // this is black magic but if it works it works
+    /// on the boundary this function does not work!! see documentation if you are interested
     bool Polygon::contains(const Vector2 &point) const {
         int c = 0;
         int n = amountOfVertices();
@@ -152,24 +152,17 @@ namespace rtt {
         std::vector<Vector2> intersections;
         size_t n = vertices.size();
         for (size_t i = 0; i < n; i++) {
-            LineSegment segment(vertices[i],
-                                vertices[(i + 1) % n]);
-            // maybe there is a nice way to do this 'circular' access with iterators?
-            // the nonSimple intersects does not count any intersection that only touch the start or end of the line
-            auto intersect = line.nonSimpleIntersects(segment);
-            if (intersect) {
-                intersections.push_back(*intersect);
-            }
-            // check the vertices explicitly (so we don't double count if we do line intersection)
-            if (line.isOnLine(vertices[i])) {
-                intersections.push_back(vertices[i]);
-            }
+            LineSegment segment(vertices[i], vertices[(i + 1) % n]);
+            std::vector<Vector2> line_intersections = line.correctIntersects(segment);
+            intersections.insert(intersections.end(), line_intersections.begin(), line_intersections.end());
         }
+        std::sort(intersections.begin(), intersections.end());
+        intersections.erase(std::unique(intersections.begin(), intersections.end()), intersections.end());
         return intersections;
     }
 
-//https://en.wikipedia.org/wiki/Shoelace_formula
-// area is well defined only for simple polygons
+    //https://en.wikipedia.org/wiki/Shoelace_formula
+    // area is well defined only for simple polygons
     double Polygon::area() const {
         return 0.5 * abs(doubleSignedArea());
     }
@@ -184,8 +177,8 @@ namespace rtt {
 
     }
 
-//https://en.wikipedia.org/wiki/Centroid
-// only works for simple polygons
+    //https://en.wikipedia.org/wiki/Centroid
+    // only works for simple polygons
     Vector2 Polygon::centroid() const {
         // for triangles we can use a faster and simpler formula
         if (amountOfVertices() < 4) {
@@ -204,7 +197,7 @@ namespace rtt {
         return sum /= (3 * signedAreaTwice);
     }
 
-// the centroid of the set of vertices. is generally NOT the same as centroid for polygons with more than 3 sides
+    // the centroid of the set of vertices. is generally NOT the same as centroid for polygons with more than 3 sides
     Vector2 Polygon::verticeCentroid() const {
         return std::accumulate(vertices.begin(), vertices.end(), Vector2(0, 0)) /= vertices.size();
     }

--- a/test/LineTest.cpp
+++ b/test/LineTest.cpp
@@ -2,28 +2,28 @@
 // Created by rolf on 19-4-19.
 //
 
+#include <gtest/gtest.h>
+#include <math.h>
 #include "roboteam_utils/Line.h"
 #include "roboteam_utils/LineSegment.h"
 #include "roboteam_utils/Vector2.h"
-#include <gtest/gtest.h>
-#include <math.h>
 using namespace rtt;
 TEST(LineTests, direction) {
     Vector2 v1(0.0, 0.0), v2(1.0, 1.0), v3(0.0, 0.0);
     Line l1(v1, v2), l2(v2, v1);
     l1.direction();
     EXPECT_EQ(l1.direction(), v2);
-    EXPECT_EQ(l2.direction(), v2*- 1.0);
+    EXPECT_EQ(l2.direction(), v2 * -1.0);
     EXPECT_NE(l1.direction(), l2.direction());
     Line l3(v1, v3);
     EXPECT_TRUE(l3.isPoint());
     EXPECT_FALSE(l1.isPoint());
     EXPECT_FALSE(l2.isPoint());
     Vector2 v4(0.0, 0.0), v5(0.0, 10.0), v6(2.0, 0.0), v7(2.0, 9.0);
-    Vector2 v8(2.0, 0.0), v9(3.0, 10.0), v10(0.0+std::numeric_limits<double>::epsilon(),10);
+    Vector2 v8(2.0, 0.0), v9(3.0, 10.0), v10(0.0 + std::numeric_limits<double>::epsilon(), 10);
     Line l4(v4, v5), l5(v6, v7);
     Line l6(v4, v8), l7(v5, v9);
-    Line l8(v4,v10);
+    Line l8(v4, v10);
     EXPECT_TRUE(l4.isParallel(l5));
     EXPECT_TRUE(l5.isParallel(l4));
     EXPECT_TRUE(l6.isParallel(l7));
@@ -42,39 +42,38 @@ TEST(LineTests, direction) {
     EXPECT_FALSE(l7.isParallel(l4));
     EXPECT_FALSE(l7.isParallel(l5));
     EXPECT_FALSE(l4.isParallel(l8));
-
 }
 TEST(LineTests, slopeAndIntercept) {
     Vector2 Av(1.0, 1.0), Bv(2.0, 2.0), Cv(2.0, 3.0), Dv(1.0, 4.0), Ev(2.0, 0.0);
     Line D(Av, Bv), E(Av, Cv), F(Av, Dv), G(Dv, Av), H(Av, Ev);
     Line Dcopy(Bv, Av), Ecopy(Cv, Av), Hcopy(Ev, Av);
 
-//test normal slopes
+    // test normal slopes
     EXPECT_DOUBLE_EQ(D.slope(), 1.0);
     EXPECT_DOUBLE_EQ(E.slope(), 2.0);
-    EXPECT_DOUBLE_EQ(H.slope(), - 1.0);
-//test vertical lines giving back numeric limits
+    EXPECT_DOUBLE_EQ(H.slope(), -1.0);
+    // test vertical lines giving back numeric limits
     EXPECT_DOUBLE_EQ(F.slope(), std::numeric_limits<double>::infinity());
-    EXPECT_DOUBLE_EQ(G.slope(), - std::numeric_limits<double>::infinity());
+    EXPECT_DOUBLE_EQ(G.slope(), -std::numeric_limits<double>::infinity());
     EXPECT_FALSE(D.isVertical());
     EXPECT_FALSE(E.isVertical());
     EXPECT_FALSE(H.isVertical());
     EXPECT_TRUE(F.isVertical());
     EXPECT_TRUE(G.isVertical());
-// make sure the functions are commutative
+    // make sure the functions are commutative
     EXPECT_DOUBLE_EQ(D.slope(), Dcopy.slope());
     EXPECT_DOUBLE_EQ(E.slope(), Ecopy.slope());
     EXPECT_DOUBLE_EQ(H.slope(), Hcopy.slope());
 
-// calculate the intercept for normal cases and check commutativity
+    // calculate the intercept for normal cases and check commutativity
     EXPECT_DOUBLE_EQ(D.intercept(), 0.0);
-    EXPECT_DOUBLE_EQ(E.intercept(), - 1.0);
+    EXPECT_DOUBLE_EQ(E.intercept(), -1.0);
     EXPECT_DOUBLE_EQ(H.intercept(), 2.0);
     EXPECT_DOUBLE_EQ(D.intercept(), Dcopy.intercept());
     EXPECT_DOUBLE_EQ(E.intercept(), Ecopy.intercept());
     EXPECT_DOUBLE_EQ(H.intercept(), Hcopy.intercept());
 
-    EXPECT_DOUBLE_EQ(F.intercept(), - std::numeric_limits<double>::infinity());
+    EXPECT_DOUBLE_EQ(F.intercept(), -std::numeric_limits<double>::infinity());
     EXPECT_DOUBLE_EQ(G.intercept(), std::numeric_limits<double>::infinity());
 
     EXPECT_DOUBLE_EQ(D.coefficients().first, D.slope());
@@ -116,7 +115,6 @@ TEST(LineTests, distanceToLine) {
     EXPECT_EQ(l2.project(point1), shouldProj1);
     EXPECT_EQ(l1.project(point2), shouldProj2);
     EXPECT_EQ(l2.project(point2), B);
-
 }
 TEST(LineTests, pointOnLine) {
     Vector2 A(1.0, 1.0), B(3.0, 1.0), C(1.0, 3.0), D(3.0, 3.0);
@@ -128,7 +126,7 @@ TEST(LineTests, pointOnLine) {
     EXPECT_TRUE(ls1.isOnLine(point1));
     EXPECT_FALSE(ls1.isOnLine(point2));
 
-//check the original points
+    // check the original points
     EXPECT_TRUE(l1.isOnLine(B));
     EXPECT_TRUE(ls1.isOnLine(B));
     EXPECT_TRUE(l1.isOnLine(A));
@@ -138,7 +136,7 @@ TEST(LineTests, pointOnLine) {
     EXPECT_TRUE(l2.isOnLine(point3));
     EXPECT_TRUE(l2.isOnLine(point4));
     EXPECT_TRUE(ls2.isOnLine(point3));
-    EXPECT_FALSE(ls2.isOnLine(point4));//check the original points
+    EXPECT_FALSE(ls2.isOnLine(point4));  // check the original points
 
     EXPECT_TRUE(l2.isOnLine(C));
     EXPECT_TRUE(ls2.isOnLine(C));
@@ -149,13 +147,12 @@ TEST(LineTests, pointOnLine) {
     EXPECT_TRUE(l3.isOnLine(point5));
     EXPECT_TRUE(l3.isOnLine(point6));
     EXPECT_TRUE(ls3.isOnLine(point5));
-    EXPECT_FALSE(ls3.isOnLine(point6));//check the original points
+    EXPECT_FALSE(ls3.isOnLine(point6));  // check the original points
 
     EXPECT_TRUE(l3.isOnLine(D));
     EXPECT_TRUE(ls3.isOnLine(D));
     EXPECT_TRUE(l3.isOnLine(A));
     EXPECT_TRUE(ls3.isOnLine(A));
-
 }
 
 TEST(LineTests, Intersections) {
@@ -167,21 +164,21 @@ TEST(LineTests, Intersections) {
     ASSERT_NE(L1.intersects(L2), std::nullopt);
     ASSERT_TRUE(L1.doesIntersect(L2));
     EXPECT_EQ(*L1.intersects(L2), intersect);
-//test converse
+    // test converse
     ASSERT_NE(L2.intersects(L1), std::nullopt);
     ASSERT_TRUE(L2.doesIntersect(L1));
     EXPECT_EQ(*L2.intersects(L1), intersect);
 
     ASSERT_EQ(LS1.intersects(LS2), std::nullopt);
     ASSERT_FALSE(LS1.doesIntersect(LS2));
-//test converse
+    // test converse
     ASSERT_EQ(LS2.intersects(LS1), std::nullopt);
     ASSERT_FALSE(LS2.doesIntersect(LS1));
 
     ASSERT_NE(L2.intersects(L4), std::nullopt);
     ASSERT_TRUE(L2.doesIntersect(L4));
     EXPECT_EQ(*L2.intersects(L4), intersect);
-//test converse
+    // test converse
     ASSERT_NE(L4.intersects(L2), std::nullopt);
     ASSERT_TRUE(L4.doesIntersect(L2));
     EXPECT_EQ(*L4.intersects(L2), intersect);
@@ -189,7 +186,7 @@ TEST(LineTests, Intersections) {
     ASSERT_NE(LS2.intersects(LS4), std::nullopt);
     ASSERT_TRUE(LS2.doesIntersect(LS4));
     EXPECT_EQ(*LS2.intersects(LS4), intersect);
-//test converse
+    // test converse
     ASSERT_NE(LS4.intersects(LS2), std::nullopt);
     ASSERT_TRUE(LS4.doesIntersect(LS2));
     EXPECT_EQ(*LS4.intersects(LS2), intersect);
@@ -197,7 +194,7 @@ TEST(LineTests, Intersections) {
     ASSERT_NE(L3.intersects(L4), std::nullopt);
     ASSERT_TRUE(L3.doesIntersect(L4));
     EXPECT_EQ(*L3.intersects(L4), P5);
-//test converse
+    // test converse
     ASSERT_NE(L4.intersects(L3), std::nullopt);
     ASSERT_TRUE(L4.doesIntersect(L3));
     EXPECT_EQ(*L4.intersects(L3), P5);
@@ -205,23 +202,22 @@ TEST(LineTests, Intersections) {
     ASSERT_NE(LS3.intersects(LS4), std::nullopt);
     ASSERT_TRUE(LS3.doesIntersect(LS4));
     EXPECT_EQ(*LS3.intersects(LS4), P5);
-//test converse
+    // test converse
     ASSERT_NE(LS4.intersects(LS3), std::nullopt);
     ASSERT_TRUE(LS4.doesIntersect(LS3));
     EXPECT_EQ(*LS4.intersects(LS3), P5);
 
     EXPECT_EQ(L3.intersects(L5), std::nullopt);
     EXPECT_FALSE(L3.doesIntersect(L5));
-//test converse
+    // test converse
     EXPECT_EQ(L5.intersects(L3), std::nullopt);
     EXPECT_FALSE(L5.doesIntersect(L3));
 
     EXPECT_EQ(LS3.intersects(LS5), std::nullopt);
     EXPECT_FALSE(LS3.doesIntersect(LS5));
-//test converse
+    // test converse
     EXPECT_EQ(LS5.intersects(LS3), std::nullopt);
     EXPECT_FALSE(LS5.doesIntersect(LS3));
-
 }
 TEST(LineTests, IntersectionsDifferentTypes) {
     Vector2 P1(0.0, 0.0), P2(2.0, 2.0), P3(2.0, 0.0), P4(0.0, 2.0);
@@ -229,7 +225,7 @@ TEST(LineTests, IntersectionsDifferentTypes) {
     Line L1(P1, P2), L2(P3, P4);
     LineSegment LS1(P1, P2), LS2(P3, P4);
 
-// no special things, just normal intersection. Should work as expected
+    // no special things, just normal intersection. Should work as expected
     ASSERT_NE(LS1.intersects(L2), std::nullopt);
     ASSERT_EQ(*LS1.intersects(L2), middle);
     ASSERT_NE(L2.intersects(LS1), std::nullopt);
@@ -244,8 +240,8 @@ TEST(LineTests, IntersectionsDifferentTypes) {
     EXPECT_TRUE(L2.doesIntersect(LS1));
     EXPECT_TRUE(L1.doesIntersect(LS2));
 
-// Lies in the extension of the line
-    Vector2 R1(0.0, 0.0), R2(1.0, 0.0), R3(0.0, - 4.0), R4(8.0, 4.0);
+    // Lies in the extension of the line
+    Vector2 R1(0.0, 0.0), R2(1.0, 0.0), R3(0.0, -4.0), R4(8.0, 4.0);
     Line A1(R1, R2), A2(R3, R4);
     LineSegment AS1(R1, R2), AS2(R3, R4);
 
@@ -255,14 +251,59 @@ TEST(LineTests, IntersectionsDifferentTypes) {
     EXPECT_TRUE(A1.doesIntersect(AS2));
     EXPECT_EQ(*A1.intersects(AS2), Vector2(4.0, 0.0));
 
-
-//edge cases
-    Vector2 R5(1.0, 3.0), R6(1.0, - 1.0), R7(2.0, 0.0), R8(3.0, 0.0);
+    // edge cases
+    Vector2 R5(1.0, 3.0), R6(1.0, -1.0), R7(2.0, 0.0), R8(3.0, 0.0);
     Line A3(R5, R6), A4(R2, R7), A5(R7, R8);
     LineSegment AS3(R5, R6), AS4(R2, R7), AS5(R7, R8);
 
     ASSERT_NE(AS1.intersects(AS4), std::nullopt);
     EXPECT_TRUE(AS1.doesIntersect(AS4));
     EXPECT_EQ(*AS1.intersects(AS4), R2);
+}
 
+TEST(LineTests, ForwardIntersect) {
+    Vector2 forwardLine_start(0.0, 0.0), forwardLine_end(2.0, 2.0);
+    Vector2 line1_start(-1.0, -3.0), line1_end(-1.0, -2.0), line2_start(1.0, 4.0), line2_end(1.0, 5.0), line3_start(-1.0, 1.0), line3_end(1.0, -1.0),
+        line4_start(1000000000.0, -1000000000.0), line4_end(1000000000.0, -99999999.0), line5_start(1.0, 1.0), line5_end(3.0, 3.0);
+    Line forwardLine(forwardLine_start, forwardLine_end), line1(line1_start, line1_end), line2(line2_start, line2_end), line3(line3_start, line3_end),
+        line4(line4_start, line4_end), line5(line5_start, line5_end);
+    std::optional<Vector2> result = line1.forwardIntersect(forwardLine);
+    EXPECT_FALSE(result.has_value());  // They do intersect, but not in positive direction
+    result = line2.forwardIntersect(forwardLine);
+    EXPECT_EQ(result, Vector2(1.0, 1.0));  // An half-way past intersection in positive direction
+    result = line3.forwardIntersect(forwardLine);
+    EXPECT_EQ(result, Vector2(0.0, 0.0));  // Boundary case where an intersection happens at the start of the forwardline
+    result = line4.forwardIntersect(forwardLine);
+    EXPECT_EQ(result, Vector2(1000000000.0, 1000000000.0));  // Far away forward intersection for both lines
+    result = line5.forwardIntersect(forwardLine);
+    EXPECT_FALSE(result.has_value());  // No intersection is returned in case the lines are the same
+}
+
+TEST(LineTests, Shadow) {
+    Vector2 source(1.0, 2.0), projectLine_start(-4.0, -6.0), projectLine_end(-4.0, 6.0), blockLine1_start(0.0, 2.0), blockLine1_end(0.0, 2.0), blockLine2_start(-1.0, 0.0),
+        blockLine2_end(-1.0, 2.0), blockLine3_start(1.0, 1.0), blockLine3_end(0.0, 0.0), blockLine4_start(1.0, 3.0), blockLine4_end(0.0, 2.0), blockLine5_start(0.0, -4.0),
+        blockLine5_end(0.0, 4.0), blockLine6_start(1.0, 2.0), blockLine6_end(1.0, 2.0), blockLine7_start(1.0, 0.0), blockLine7_end(1000000000.0, 0.0), blockLine8_start(-1.0, 1.0),
+        blockLine8_end(-3.0, -1.0), checkLine2_start(-4.0, -3.0), checkLine2_end(-4.0, 2.0), checkLine4_start(-4.0, 2.0), checkLine4_end(-4.0, 6.0), checkLine8_start(-4.0, -0.5),
+        checkLine8_end(-4.0, -1.75);
+    LineSegment projectLine(projectLine_start, projectLine_end), blockLine1(blockLine1_start, blockLine1_end), blockLine2(blockLine2_start, blockLine2_end),
+        blockLine3(blockLine3_start, blockLine3_end), blockLine4(blockLine4_start, blockLine4_end), blockLine5(blockLine5_start, blockLine5_end),
+        blockLine6(blockLine6_start, blockLine6_end), blockLine7(blockLine7_start, blockLine7_end), blockLine8(blockLine8_start, blockLine8_end),
+        checkLine2(checkLine2_start, checkLine2_end), checkLine4(checkLine4_start, checkLine4_end), checkLine8(checkLine8_start, checkLine8_end);
+
+    std::optional<LineSegment> result = projectLine.shadow(source, blockLine1);
+    EXPECT_FALSE(result.has_value());  // A single point cannot cause a shadow (except if it lies at the source)
+    result = projectLine.shadow(source, blockLine2);
+    EXPECT_TRUE(result.value() == checkLine2);  // Part of the line is covered by a shadow
+    result = projectLine.shadow(source, blockLine3);
+    EXPECT_FALSE(result.has_value());  // Line that does not cause a shadow at all
+    result = projectLine.shadow(source, blockLine4);
+    EXPECT_TRUE(result.value() == checkLine4);  // Only shadow at upper part, projected line on the end of the blockline goes parallel to the projection line
+    result = projectLine.shadow(source, blockLine5);
+    EXPECT_TRUE(result.value() == projectLine);  // Entire project line is shadowed by obstacle
+    result = projectLine.shadow(source, blockLine6);
+    EXPECT_TRUE(result.value() == projectLine);  // The source is in the obstacle so everything is in the shadow
+    result = projectLine.shadow(source, blockLine7);
+    EXPECT_FALSE(result.has_value());  // Line that is very long, but does not cause a shadow at all because it is not in between the project line and source
+    result = projectLine.shadow(source, blockLine8);
+    EXPECT_TRUE(result.value() == checkLine8);
 }


### PR DESCRIPTION
Solved inconsistent implementation of Polygon intersect. From now on the intersections with the boundary of the Polygon are computed and the behaviour is specified as follows:
- If there is no intersection then an empty vector is returned.
- If there is 1 intersection then a vector with only that intersection point is returned.
- If there are 2 intersections then a vector with both intersection points is returned.
- If there are infinitely many intersections then these intersection are all on a LineSegment in which case the start and end point of this LineSegment are returned.

In the past you could have unexpected behaviour for lines that start and/or end at the boundary of the Polygon in which case this function does not return any intersection.

Note: only merge this PR after Added Shadow functionality to LineSegment class #57 is merged.