### PR TITLE
Fix bug in ShortestAngleDiff

### DIFF
--- a/include/roboteam_utils/Angle.h
+++ b/include/roboteam_utils/Angle.h
@@ -57,22 +57,6 @@ namespace rtt {
         void setAngle(double other) noexcept;
 
         /**
-         * @brief Gets the difference in angle between this angle and other
-         *
-         * @param other Other angle
-         * @return double angle
-         */
-        [[nodiscard]] double angleDiff(Angle const &other) const noexcept;
-
-        /**
-         * @brief Gets the difference between this.angle and other
-         *
-         * @param other Other angle
-         * @return double amount difference
-         */
-        [[nodiscard]] double angleDiff(double other) const noexcept;
-
-        /**
          * @brief Gets the angleDiff of the shortest angle (*this vs other)
          *
          * @param other Other angle to get from
@@ -234,6 +218,13 @@ namespace rtt {
          */
         Angle constrain() noexcept;
 
+        /**
+         * @brief Gets the absolute difference in angle between this angle and other
+         *
+         * @param other Other angle
+         * @return double angle
+         */
+        [[nodiscard]] double angleDiff(Angle const &other) const noexcept;
     };
 
 } // rtt

--- a/include/roboteam_utils/Angle.h
+++ b/include/roboteam_utils/Angle.h
@@ -217,14 +217,6 @@ namespace rtt {
          * @return Angle A copy of `*this`
          */
         Angle constrain() noexcept;
-
-        /**
-         * @brief Gets the absolute difference in angle between this angle and other
-         *
-         * @param other Other angle
-         * @return double angle
-         */
-        [[nodiscard]] double angleDiff(Angle const &other) const noexcept;
     };
 
 } // rtt

--- a/src/Angle.cpp
+++ b/src/Angle.cpp
@@ -33,13 +33,9 @@ namespace rtt {
         return *this;
     }
 
-    double Angle::angleDiff(Angle const &other) const noexcept {
-        return abs((*this - other).angle);
-    }
-
     double Angle::shortestAngleDiff(Angle const &other) const noexcept {
-        double thisDiff = angleDiff(other);
-        double otherDiff = other.angleDiff(*this);
+        double thisDiff = abs((*this - other).angle);
+        double otherDiff = abs((other - *this).angle);
         return std::min(thisDiff, otherDiff);
     }
 

--- a/src/Angle.cpp
+++ b/src/Angle.cpp
@@ -34,19 +34,13 @@ namespace rtt {
     }
 
     double Angle::angleDiff(Angle const &other) const noexcept {
-        return (*this - other).angle;
-    }
-
-    double Angle::angleDiff(double scalar) const noexcept {
-        Angle other = Angle(scalar);
-        return this->angleDiff(other);
+        return abs((*this - other).angle);
     }
 
     double Angle::shortestAngleDiff(Angle const &other) const noexcept {
-        if (this->angleDiff(other) > other.angleDiff(*this))
-            return other.angleDiff(*this);
-        else
-            return this->angleDiff(other);
+        double thisDiff = angleDiff(other);
+        double otherDiff = other.angleDiff(*this);
+        return std::min(thisDiff, otherDiff);
     }
 
     double Angle::shortestAngleDiff(double &scalar) const noexcept {


### PR DESCRIPTION
A bug in the ShortestAngleDiff function has been fixed. From now on always the shortest absolute angle is returned whereas in the past it could be the case that the longest angle was returned (that had a negative value).