### PR TITLE
Change grids to generate points centered in the grid

### DIFF
--- a/include/roboteam_utils/Grid.h
+++ b/include/roboteam_utils/Grid.h
@@ -11,7 +11,7 @@ namespace rtt {
     class Grid {
     public:
         /**
-         * A Grid is a 2D vector of Vector2 points.
+         * A Grid is a 2D vector of Vector2 points. The points will be evenly spaced and centered (avg x and y will be 0) in the given range.
          * @param offSetX the distance you want to horizontally shift the grid from 0 (where 0 is left edge)
          * @param offSetY the distance you want to vertically shift the grid from 0 (where 0 is bottom edge)
          * @param regionWidth the width of the region you want the grid to encompass

--- a/include/roboteam_utils/Grid.h
+++ b/include/roboteam_utils/Grid.h
@@ -47,4 +47,4 @@ namespace rtt {
     };
 }
 
-#endif //RTT_GRID_H
+#endif  // RTT_GRID_H

--- a/include/roboteam_utils/Grid.h
+++ b/include/roboteam_utils/Grid.h
@@ -15,16 +15,16 @@ namespace rtt {
          * @param offSetX the distance you want to horizontally shift the grid from 0 (where 0 is left edge)
          * @param offSetY the distance you want to vertically shift the grid from 0 (where 0 is bottom edge)
          * @param regionWidth the width of the region you want the grid to encompass
-         * @param regionHeight the height of the region you want the grid to encompass
+         * @param regionLength the length of the region you want the grid to encompass
          * @param numStepsX number of segments to divide the grid into in x direction
          * @param numStepsY number of segments to divide the grid into in y direction
          */
-        Grid(double offSetX, double offSetY, double regionWidth, double regionHeight, int numSegmentsX, int numSegmentsY);
+        Grid(double offSetX, double offSetY, double regionWidth, double regionLength, int numSegmentsX, int numSegmentsY);
 
         [[nodiscard]] double getOffSetX() const;
         [[nodiscard]] double getOffSetY() const;
         [[nodiscard]] double getRegionWidth() const;
-        [[nodiscard]] double getRegionHeight() const;
+        [[nodiscard]] double getRegionLength() const;
         [[nodiscard]] int getNumSegmentsX() const;
         [[nodiscard]] int getNumSegmentsY() const;
         [[nodiscard]] double getStepSizeX() const;
@@ -39,7 +39,7 @@ namespace rtt {
         double offSetX;
         double offSetY;
         double regionWidth;
-        double regionHeight;
+        double regionLength;
         int numSegmentsX;
         int numSegmentsY;
         double stepSizeX;

--- a/src/utils/Grid.cpp
+++ b/src/utils/Grid.cpp
@@ -4,68 +4,44 @@
 
 #include "Grid.h"
 namespace rtt {
-    Grid::Grid(double offSetX, double offSetY, double regionWidth, double regionLength, int numSegmentsX, int numSegmentsY) :
-    offSetX{offSetX},
-    offSetY{offSetY},
-    regionWidth{regionWidth},
-    regionLength{regionLength},
-    numSegmentsX{numSegmentsX},
-    numSegmentsY{numSegmentsY}
-    {
-        this->stepSizeX = regionLength/numSegmentsX;
-        this->stepSizeY = regionWidth/numSegmentsY;
+Grid::Grid(double offSetX, double offSetY, double regionWidth, double regionLength, int numSegmentsX, int numSegmentsY)
+    : offSetX{offSetX}, offSetY{offSetY}, regionWidth{regionWidth}, regionLength{regionLength}, numSegmentsX{numSegmentsX}, numSegmentsY{numSegmentsY} {
+    this->stepSizeX = regionLength / numSegmentsX;
+    this->stepSizeY = regionWidth / numSegmentsY;
 
-        for (int i = 0; i <= numSegmentsX; i++) {
-            std::vector<Vector2> a;
-            points.emplace_back(a);
-        }
+    for (int i = 0; i <= numSegmentsX; i++) {
+        std::vector<Vector2> a;
+        points.emplace_back(a);
+    }
 
-        for (int i = 0; i < numSegmentsX; i++) {
-            for (int j = 0; j < numSegmentsY; j++) {
-                points[i].emplace_back(Vector2(offSetX + stepSizeX * i + stepSizeX/2, offSetY + stepSizeY * j + stepSizeY/2));
-            }
+    for (int i = 0; i < numSegmentsX; i++) {
+        for (int j = 0; j < numSegmentsY; j++) {
+            points[i].emplace_back(Vector2(offSetX + stepSizeX * i + stepSizeX / 2, offSetY + stepSizeY * j + stepSizeY / 2));
         }
     }
-
-    /**
-     * Remember this vector returns a nested list of points,
-     * so you will want to loop through both vectors to get the full grid
-     * @return points, the nested vector containing all Vector2 points within this grid
-     */
-    const std::vector<std::vector<Vector2>> &Grid::getPoints() const {
-        return points;
-    }
-
-    double Grid::getOffSetX() const {
-        return offSetX;
-    }
-
-    double Grid::getOffSetY() const {
-        return offSetY;
-    }
-
-    double Grid::getRegionWidth() const {
-        return regionWidth;
-    }
-
-    double Grid::getRegionLength() const {
-        return regionLength;
-    }
-
-    int Grid::getNumSegmentsX() const {
-        return numSegmentsX;
-    }
-
-    int Grid::getNumSegmentsY() const {
-        return numSegmentsY;
-    }
-
-    double Grid::getStepSizeX() const {
-        return stepSizeX;
-    }
-
-    double Grid::getStepSizeY() const {
-        return stepSizeY;
-    }
-
 }
+
+/**
+ * Remember this vector returns a nested list of points,
+ * so you will want to loop through both vectors to get the full grid
+ * @return points, the nested vector containing all Vector2 points within this grid
+ */
+const std::vector<std::vector<Vector2>> &Grid::getPoints() const { return points; }
+
+double Grid::getOffSetX() const { return offSetX; }
+
+double Grid::getOffSetY() const { return offSetY; }
+
+double Grid::getRegionWidth() const { return regionWidth; }
+
+double Grid::getRegionLength() const { return regionLength; }
+
+int Grid::getNumSegmentsX() const { return numSegmentsX; }
+
+int Grid::getNumSegmentsY() const { return numSegmentsY; }
+
+double Grid::getStepSizeX() const { return stepSizeX; }
+
+double Grid::getStepSizeY() const { return stepSizeY; }
+
+}  // namespace rtt

--- a/src/utils/Grid.cpp
+++ b/src/utils/Grid.cpp
@@ -4,16 +4,17 @@
 
 #include "Grid.h"
 namespace rtt {
-    Grid::Grid(double offSetX, double offSetY, double regionWidth, double regionHeight, int numSegmentsX, int numSegmentsY) :
+    Grid::Grid(double offSetX, double offSetY, double regionWidth, double regionLength, int numSegmentsX, int numSegmentsY) :
     offSetX{offSetX},
     offSetY{offSetY},
     regionWidth{regionWidth},
-    regionHeight{regionHeight},
+    regionLength{regionLength},
     numSegmentsX{numSegmentsX},
     numSegmentsY{numSegmentsY}
     {
-        this->stepSizeX = regionWidth/numSegmentsX;
-        this->stepSizeY = regionHeight/numSegmentsY;
+        this->stepSizeX = regionLength/numSegmentsX;
+        this->stepSizeY = regionWidth/numSegmentsY;
+
         for (int i = 0; i <= numSegmentsX; i++) {
             std::vector<Vector2> a;
             points.emplace_back(a);
@@ -47,8 +48,8 @@ namespace rtt {
         return regionWidth;
     }
 
-    double Grid::getRegionHeight() const {
-        return regionHeight;
+    double Grid::getRegionLength() const {
+        return regionLength;
     }
 
     int Grid::getNumSegmentsX() const {

--- a/src/utils/Grid.cpp
+++ b/src/utils/Grid.cpp
@@ -20,9 +20,9 @@ namespace rtt {
             points.emplace_back(a);
         }
 
-        for (int i = 0; i <= numSegmentsX; i++) {
-            for (int j = 0; j <= numSegmentsY; j++) {
-                points[i].emplace_back(Vector2(offSetX + stepSizeX * i, offSetY + stepSizeY * j));
+        for (int i = 0; i < numSegmentsX; i++) {
+            for (int j = 0; j < numSegmentsY; j++) {
+                points[i].emplace_back(Vector2(offSetX + stepSizeX * i + stepSizeX/2, offSetY + stepSizeY * j + stepSizeY/2));
             }
         }
     }


### PR DESCRIPTION
This PR changes how grids are generated by centering the points in the grid. Previously, points were generated starting in the bottom left of the grid. Now, there is a padding of half the distance between points between the side and the first point. This ensures that grids are equally covered regardless of the number of points and that grids connect seamlessly
