### PR TITLE
Improve grid positioning and naming

### DIFF
--- a/include/roboteam_utils/Grid.h
+++ b/include/roboteam_utils/Grid.h
@@ -8,43 +8,43 @@
 #include "Vector2.h"
 
 namespace rtt {
-class Grid {
-   public:
-    /**
-     * A Grid is a 2D vector of Vector2 points.
-     * @param offSetX the distance you want to horizontally shift the grid from 0 (where 0 is left edge)
-     * @param offSetY the distance you want to vertically shift the grid from 0 (where 0 is bottom edge)
-     * @param regionWidth the width of the region you want the grid to encompass
-     * @param regionHeight the height of the region you want the grid to encompass
-     * @param numStepsX number of segments to divide the grid into in x direction
-     * @param numStepsY number of segments to divide the grid into in y direction
-     */
-    Grid(double offSetX, double offSetY, double regionWidth, double regionHeight, int numSegmentsX, int numSegmentsY);
+    class Grid {
+    public:
+        /**
+         * A Grid is a 2D vector of Vector2 points. The points will be evenly spaced and centered (avg x and y will be 0) in the given range.
+         * @param offSetX the distance you want to horizontally shift the grid from 0 (where 0 is left edge)
+         * @param offSetY the distance you want to vertically shift the grid from 0 (where 0 is bottom edge)
+         * @param regionWidth the width of the region you want the grid to encompass
+         * @param regionLength the length of the region you want the grid to encompass
+         * @param numStepsX number of segments to divide the grid into in x direction
+         * @param numStepsY number of segments to divide the grid into in y direction
+         */
+        Grid(double offSetX, double offSetY, double regionWidth, double regionLength, int numSegmentsX, int numSegmentsY);
 
-    [[nodiscard]] double getOffSetX() const;
-    [[nodiscard]] double getOffSetY() const;
-    [[nodiscard]] double getRegionWidth() const;
-    [[nodiscard]] double getRegionHeight() const;
-    [[nodiscard]] int getNumSegmentsX() const;
-    [[nodiscard]] int getNumSegmentsY() const;
-    [[nodiscard]] double getStepSizeX() const;
-    [[nodiscard]] double getStepSizeY() const;
-    [[nodiscard]] const std::vector<std::vector<Vector2>> &getPoints() const;
+        [[nodiscard]] double getOffSetX() const;
+        [[nodiscard]] double getOffSetY() const;
+        [[nodiscard]] double getRegionWidth() const;
+        [[nodiscard]] double getRegionLength() const;
+        [[nodiscard]] int getNumSegmentsX() const;
+        [[nodiscard]] int getNumSegmentsY() const;
+        [[nodiscard]] double getStepSizeX() const;
+        [[nodiscard]] double getStepSizeY() const;
+        [[nodiscard]] const std::vector<std::vector<Vector2>> &getPoints() const;
 
-   private:
-    /**
-     * nested vector, first index corresponds to nth x element, second to nth y element
-     */
-    std::vector<std::vector<Vector2>> points;
-    double offSetX;
-    double offSetY;
-    double regionWidth;
-    double regionHeight;
-    int numSegmentsX;
-    int numSegmentsY;
-    double stepSizeX;
-    double stepSizeY;
-};
-}  // namespace rtt
+    private:
+        /**
+         * nested vector, first index corresponds to nth x element, second to nth y element
+         */
+        std::vector<std::vector<Vector2>> points;
+        double offSetX;
+        double offSetY;
+        double regionWidth;
+        double regionLength;
+        int numSegmentsX;
+        int numSegmentsY;
+        double stepSizeX;
+        double stepSizeY;
+    };
+}
 
 #endif  // RTT_GRID_H

--- a/src/utils/Grid.cpp
+++ b/src/utils/Grid.cpp
@@ -4,18 +4,19 @@
 
 #include "Grid.h"
 namespace rtt {
-Grid::Grid(double offSetX, double offSetY, double regionWidth, double regionHeight, int numSegmentsX, int numSegmentsY)
-    : offSetX{offSetX}, offSetY{offSetY}, regionWidth{regionWidth}, regionHeight{regionHeight}, numSegmentsX{numSegmentsX}, numSegmentsY{numSegmentsY} {
-    this->stepSizeX = regionWidth / numSegmentsX;
-    this->stepSizeY = regionHeight / numSegmentsY;
+Grid::Grid(double offSetX, double offSetY, double regionWidth, double regionLength, int numSegmentsX, int numSegmentsY)
+    : offSetX{offSetX}, offSetY{offSetY}, regionWidth{regionWidth}, regionLength{regionLength}, numSegmentsX{numSegmentsX}, numSegmentsY{numSegmentsY} {
+    this->stepSizeX = regionLength / numSegmentsX;
+    this->stepSizeY = regionWidth / numSegmentsY;
+
     for (int i = 0; i <= numSegmentsX; i++) {
         std::vector<Vector2> a;
         points.emplace_back(a);
     }
 
-    for (int i = 0; i <= numSegmentsX; i++) {
-        for (int j = 0; j <= numSegmentsY; j++) {
-            points[i].emplace_back(Vector2(offSetX + stepSizeX * i, offSetY + stepSizeY * j));
+    for (int i = 0; i < numSegmentsX; i++) {
+        for (int j = 0; j < numSegmentsY; j++) {
+            points[i].emplace_back(Vector2(offSetX + stepSizeX * i + stepSizeX / 2, offSetY + stepSizeY * j + stepSizeY / 2));
         }
     }
 }

--- a/src/utils/Grid.cpp
+++ b/src/utils/Grid.cpp
@@ -33,7 +33,7 @@ double Grid::getOffSetY() const { return offSetY; }
 
 double Grid::getRegionWidth() const { return regionWidth; }
 
-double Grid::getRegionHeight() const { return regionHeight; }
+double Grid::getRegionLength() const { return regionLength; }
 
 int Grid::getNumSegmentsX() const { return numSegmentsX; }
 


### PR DESCRIPTION
Instead of the grids starting at the bottom left point given, grids are now centered in the given region, ensuring that the generated points cover the whole region effectively and that grids fit together seamlessly.