### PR TITLE
Change intersectsCircleWithLineSegment to not need circle as argument

### DIFF
--- a/include/roboteam_utils/Circle.h
+++ b/include/roboteam_utils/Circle.h
@@ -91,7 +91,7 @@ class Circle {
     /** @brief Writes a textual representation of this circle to the given output stream */
     std::ostream& write(std::ostream& out) const;
 
-    std::vector<Vector2> intersectsCircleWithLineSegment(Circle circle, LineSegment line);
+    std::vector<Vector2> intersectsCircleWithLineSegment(LineSegment line);
 };
 
 std::ostream& operator<<(std::ostream& out, const Circle& circle);

--- a/src/utils/Circle.cpp
+++ b/src/utils/Circle.cpp
@@ -70,14 +70,14 @@ std::ostream &operator<<(std::ostream &os, rtt::Circle const &circle) { return c
 
 double sq(double x) { return x * x; }
 
-std::vector<Vector2> Circle::intersectsCircleWithLineSegment(rtt::Circle circle, rtt::LineSegment line) {
+std::vector<Vector2> Circle::intersectsCircleWithLineSegment(rtt::LineSegment line) {
     std::vector<rtt::Vector2> res;
     constexpr double eps = 1e-16;
     bool segment = true;
 
-    double x0 = circle.center.x;  // cp.first;
-    double y0 = circle.center.y;  // cp.second;
-    double r = circle.radius;
+    double x0 = this->center.x;  // cp.first;
+    double y0 = this->center.y;  // cp.second;
+    double r = this->radius;
     double x1 = line.start.x;  // p1.first;
     double y1 = line.start.y;  // p1.second;
     double x2 = line.end.x;    // p2.first;


### PR DESCRIPTION
Previously, this function was weird to call, as it is a member function that needs the object it is called on as an argument. Either this function should be static, or get the info from the this pointer instead of an argument. In line with other functions in circle, it was decided to do the latter.

**Important:** this PR goes along with another PR in AI, as this would prevent AI from building without changing the function call there too. Link: https://github.com/RoboTeamTwente/roboteam_ai/pull/1285