### PR TITLE
Change all uses of abs and std::abs to fabs

### DIFF
--- a/include/roboteam_utils/Circle.h
+++ b/include/roboteam_utils/Circle.h
@@ -33,7 +33,7 @@ class Circle {
      * @param center Center of the circle
      * @param radius Radius of the circle
      */
-    Circle(const Vector2& center, double radius) : center{center}, radius{std::abs(radius)} {};
+    Circle(const Vector2& center, double radius) : center{center}, radius{fabs(radius)} {};
     /**
      * @brief Construct a circle from another circle by copying its center and radius
      * @param other The circle from which to copy the center and radius

--- a/src/utils/Angle.cpp
+++ b/src/utils/Angle.cpp
@@ -30,8 +30,8 @@ bool Angle::rotateDirection(const Angle &other) const noexcept {
 }
 
 double Angle::shortestAngleDiff(Angle const &other) const noexcept {
-    double thisDiff = abs((*this - other).angle);
-    double otherDiff = abs((other - *this).angle);
+    double thisDiff = fabs((*this - other).angle);
+    double otherDiff = fabs((other - *this).angle);
     return std::min(thisDiff, otherDiff);
 }
 

--- a/src/utils/Circle.cpp
+++ b/src/utils/Circle.cpp
@@ -6,13 +6,13 @@
 
 namespace rtt {
 
-bool Circle::doesIntersectOrContain(const Vector2 &other) { return std::abs((center - other).length()) <= radius; }
+bool Circle::doesIntersectOrContain(const Vector2 &other) { return fabs((center - other).length()) <= radius; }
 
 bool Circle::doesIntersectOrContain(const Line &other) { return other.distanceToLine(center) <= radius; }
 
 bool Circle::doesIntersectOrContain(const LineSegment &other) { return other.distanceToLine(center) <= radius; }
 
-bool Circle::doesIntersectOrContain(const Circle &other) { return std::abs((center - other.center).length()) <= (radius + other.radius); }
+bool Circle::doesIntersectOrContain(const Circle &other) { return fabs((center - other.center).length()) <= (radius + other.radius); }
 
 bool Circle::doesIntersectOrContain(const Rectangle &other) {
     // https://stackoverflow.com/questions/401847/circle-rectangle-collision-detection-intersection
@@ -23,8 +23,8 @@ bool Circle::doesIntersectOrContain(const Rectangle &other) {
     double rectWidth = other.width();
     double rectHeight = other.height();
 
-    distanceToCircle.x = abs(center.x - rectCenter.x);
-    distanceToCircle.y = abs(center.y - rectCenter.y);
+    distanceToCircle.x = fabs(center.x - rectCenter.x);
+    distanceToCircle.y = fabs(center.y - rectCenter.y);
 
     if (distanceToCircle.x > (rectWidth / 2 + radius)) return false;
     if (distanceToCircle.y > (rectHeight / 2 + radius)) return false;
@@ -59,10 +59,10 @@ Circle Circle::operator-(const Vector2 &other) const { return {center - other, r
 Circle Circle::operator+=(const Vector2 &other) { return {center += other, radius}; }
 Circle Circle::operator-=(const Vector2 &other) { return {center -= other, radius}; }
 
-Circle Circle::operator*(double scale) const { return {center, radius * std::abs(scale)}; }
-Circle Circle::operator/(double scale) const { return {center, radius / std::abs(scale)}; }
-Circle Circle::operator*=(double scale) { return {center, radius *= std::abs(scale)}; }
-Circle Circle::operator/=(double scale) { return {center, radius /= std::abs(scale)}; }
+Circle Circle::operator*(double scale) const { return {center, radius * fabs(scale)}; }
+Circle Circle::operator/(double scale) const { return {center, radius / fabs(scale)}; }
+Circle Circle::operator*=(double scale) { return {center, radius *= fabs(scale)}; }
+Circle Circle::operator/=(double scale) { return {center, radius /= fabs(scale)}; }
 
 std::ostream &Circle::write(std::ostream &os) const { return os << "Circle({" << center.x << ", " << center.y << "}, " << radius << ")"; }
 
@@ -88,7 +88,7 @@ std::vector<Vector2> Circle::intersectsCircleWithLineSegment(rtt::LineSegment li
     double a = A * A + B * B;
     double b, c;
     bool bnz = true;
-    if (abs(B) >= eps) {
+    if (fabs(B) >= eps) {
         b = 2 * (A * C + A * B * y0 - sq(B) * x0);
         c = sq(C) + 2 * B * C * y0 - sq(B) * (sq(r) - sq(x0) - sq(y0));
     } else {
@@ -107,7 +107,7 @@ std::vector<Vector2> Circle::intersectsCircleWithLineSegment(rtt::LineSegment li
         double d2 = sqrt(sq(x - x1) + sq(y - y1));    // distance from point to one end
         double d3 = sqrt(sq(x2 - x) + sq(y2 - y));    // distance from point to other end
         double delta = d1 - d2 - d3;
-        return abs(delta) < eps;  // true if delta is less than a small tolerance
+        return fabs(delta) < eps;  // true if delta is less than a small tolerance
     };
 
     auto fx = [A, B, C](double x) { return -(A * x + C) / B; };

--- a/src/utils/Line.cpp
+++ b/src/utils/Line.cpp
@@ -1,5 +1,6 @@
 #include "Line.h"
 
+#include <cmath>
 #include <optional>
 
 #include "LineSegment.h"
@@ -37,7 +38,7 @@ Vector2 Line::project(const Vector2 &point) const {
 bool Line::isOnLine(const Vector2 &point) const {
     Vector2 A = v2 - v1;
     Vector2 B = point - v1;
-    return abs(A.cross(B)) < RTT_PRECISION_LIMIT;
+    return fabs(A.cross(B)) < RTT_PRECISION_LIMIT;
 }
 
 std::optional<Vector2> Line::intersect(const Line &line) const {
@@ -55,7 +56,7 @@ std::optional<Vector2> Line::intersect(const Vector2 p1, const Vector2 p2, const
     Vector2 A = p1 - p2;
     Vector2 B = q1 - q2;
     double denom = A.cross(B);
-    if (abs(denom) >= RTT_PRECISION_LIMIT) {
+    if (fabs(denom) >= RTT_PRECISION_LIMIT) {
         Vector2 C = p1 - q1;
         double numer = C.cross(A);
         double u = numer / denom;

--- a/src/utils/Polygon.cpp
+++ b/src/utils/Polygon.cpp
@@ -4,6 +4,7 @@
 
 #include "Polygon.h"
 
+#include <cmath>
 #include <numeric>
 #include <optional>
 #include <utility>
@@ -122,7 +123,7 @@ std::vector<Vector2> Polygon::intersections(const LineSegment &line) const {
 
 // https://en.wikipedia.org/wiki/Shoelace_formula
 //  area is well defined only for simple polygons
-double Polygon::area() const { return 0.5 * abs(doubleSignedArea()); }
+double Polygon::area() const { return 0.5 * fabs(doubleSignedArea()); }
 
 double Polygon::doubleSignedArea() const {
     int n = vertices.size();

--- a/src/utils/Rectangle.cpp
+++ b/src/utils/Rectangle.cpp
@@ -39,8 +39,8 @@ double Rectangle::minX() const { return fmin(corner1.x, corner2.x); }
 double Rectangle::maxX() const { return fmax(corner1.x, corner2.x); }
 double Rectangle::minY() const { return fmin(corner1.y, corner2.y); }
 double Rectangle::maxY() const { return fmax(corner1.y, corner2.y); }
-double Rectangle::width() const { return std::abs(corner1.x - corner2.x); }
-double Rectangle::height() const { return std::abs(corner1.y - corner2.y); }
+double Rectangle::width() const { return fabs(corner1.x - corner2.x); }
+double Rectangle::height() const { return fabs(corner1.y - corner2.y); }
 
 std::vector<Vector2> Rectangle::corners() const {
     std::vector<Vector2> corners = {Vector2(minX(), minY()), Vector2(minX(), maxY()), Vector2(maxX(), maxY()), Vector2(maxX(), minY())};

--- a/src/utils/Triangle.cpp
+++ b/src/utils/Triangle.cpp
@@ -20,7 +20,7 @@ bool Triangle::contains(const Vector2 &point) const {
     }
     return ((((corner3.x - corner2.x) * (point.y - corner2.y) - (corner3.y - corner2.y) * (point.x - corner2.x)) >= 0) == s_ab);
 }
-double Triangle::area() const { return abs((corner1.x * (corner2.y - corner3.y) + corner2.x * (corner3.y - corner1.y) + corner3.x * (corner1.y - corner2.y)) * 0.5); }
+double Triangle::area() const { return fabs((corner1.x * (corner2.y - corner3.y) + corner2.x * (corner3.y - corner1.y) + corner3.x * (corner1.y - corner2.y)) * 0.5); }
 std::vector<LineSegment> Triangle::lines() const { return std::vector<LineSegment>({LineSegment(corner1, corner2), LineSegment(corner2, corner3), LineSegment(corner3, corner1)}); }
 std::vector<Vector2> Triangle::corners() const { return std::vector<Vector2>({corner1, corner2, corner3}); }
 bool Triangle::doesIntersect(const Line &line) const {

--- a/test/utils/RandomTest.cpp
+++ b/test/utils/RandomTest.cpp
@@ -43,7 +43,7 @@ TEST(Random, gaussian) {
         }
         sum /= (double)n;
         double sigma = 1 / sqrt(n);
-        successes += (abs(sum) <= 2 * sigma);  // 95 % confidence interval.
+        successes += (fabs(sum) <= 2 * sigma);  // 95 % confidence interval.
     }
     EXPECT_GE(successes, 90);  // Leave some width for 95% confidence interval.
     // The actual value is 94, which is a good indication everything works as intended.


### PR DESCRIPTION
abs, by default, returns integral types. Std::abs can deal with floats/doubles. When using namespace std; abs will be seen as std::abs, which will result in correct behaviour when dealing with floats. When this using declaration is removed, however, no errors will be given but the behaviour will be incorrect. By using fabs (from <cmath>), we ensure that floats are always handled correctly.