### PR TITLE
Use correct compiler flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ target_include_directories(roboteam_utils
         PRIVATE include/roboteam_utils
         INTERFACE include
         )
+target_compile_options(roboteam_utils PRIVATE "${COMPILER_FLAGS}")
 
 add_executable(utils_tests
         ${ROBOTEAM_UTILS_TEST_SRC}


### PR DESCRIPTION
This PR adds the compiler flags specified in the main CMakeLists file of roboteam_suite. Therefore, this PR is dependent on [the PR in suite](https://github.com/RoboTeamTwente/roboteam_suite/pull/33)