### PR TITLE
Use correct compiler flags (v2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ target_include_directories(roboteam_utils
         INTERFACE include
         )
 
+target_compile_options(roboteam_utils PRIVATE "${COMPILER_FLAGS}")
+
 add_executable(utils_tests
         ${ROBOTEAM_UTILS_TEST_SRC}
         )
@@ -68,3 +70,4 @@ target_link_libraries(utils_tests
         PRIVATE gtest
         PRIVATE pthread
         )
+target_compile_options(utils_tests PRIVATE "${COMPILER_FLAGS}")


### PR DESCRIPTION
This PR adds the compiler flags specified in the main CMakeLists file of roboteam_suite. Therefore, this PR is dependent on [the PR in suite](https://github.com/RoboTeamTwente/roboteam_suite/pull/33)

This is the new attempt to a proper pull request after [the old one](https://github.com/RoboTeamTwente/roboteam_utils/pull/107)