### PR TITLE
Add shared RobotCommands data structure

### DIFF
--- a/include/roboteam_utils/RobotCommands.hpp
+++ b/include/roboteam_utils/RobotCommands.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <roboteam_utils/Vector2.h>
+#include <roboteam_utils/Angle.h>
+
+#include <vector>
+
+namespace rtt {
+
+enum class KickType {
+    NORMAL, // Horizontal kicking
+    CHIP    // Diagonally in the air kicking
+};
+
+typedef struct RobotCommand {
+    unsigned int id = -1;           // [0,15] The id of robot
+    
+    // Positioning related variables
+    Vector2 velocity;               // (m/s) Target velocity of the robot
+    Angle targetAngle;              // (rad) [-PI, PI] The target angle of the robot
+    double targetAngularVelocity;   // (rad/s) The target angular velocity of the robot
+    bool useAngularVelocity;        // True if angular velocity should be used instead of angle
+
+    Angle cameraAngleOfRobot;       // (rad) The current angle of the robot according to the camera
+    bool cameraAngleOfRobotIsSet;   // True if the cameraAngleOfRobot is set. If false, these fields should be ignored
+    
+    // Action related variables
+    double kickSpeed;        // (m/s) [0, 6.5] The target speed of the ball. 0.0 means the robot should not kick
+    bool waitForBall;       // Will make the robot wait with kicking untill it has the ball
+    KickType kickType;      // Defines the type of kicking, either normal(horizontal) or chipping(vertical)
+    
+    double dribblerSpeed;    // [0, 1] Speed of the dribbler
+    
+    bool ignorePacket;  // Robot will ignore packet, but robot will reply with feedback
+} RobotCommand;
+
+/* This object represents robot commands that are sent from AI to RobotHub */
+typedef std::vector<RobotCommand> RobotCommands;
+
+} // namespace rtt

--- a/include/roboteam_utils/RobotCommands.hpp
+++ b/include/roboteam_utils/RobotCommands.hpp
@@ -8,30 +8,31 @@
 namespace rtt {
 
 enum class KickType {
+    NO_KICK,// For not kicking the ball
     KICK,   // Horizontal kicking
     CHIP    // Diagonally in the air kicking
 };
 
 typedef struct RobotCommand {
-    int id;           // [0,15] The id of robot
+    int id = 0;                             // [0,15] The id of robot
     
     // Positioning related variables
-    Vector2 velocity;               // (m/s) Target velocity of the robot
-    Angle targetAngle;              // (rad) [-PI, PI] The target angle of the robot
-    double targetAngularVelocity;   // (rad/s) The target angular velocity of the robot
-    bool useAngularVelocity;        // True if angular velocity should be used instead of angle
+    Vector2 velocity;                       // (m/s) Target velocity of the robot
+    Angle targetAngle;                      // (rad) [-PI, PI] The target angle of the robot
+    double targetAngularVelocity = 0.0;     // (rad/s) The target angular velocity of the robot
+    bool useAngularVelocity = 0.0;          // True if angular velocity should be used instead of angle
 
-    Angle cameraAngleOfRobot;       // (rad) The current angle of the robot according to the camera
-    bool cameraAngleOfRobotIsSet;   // True if the cameraAngleOfRobot is set. If false, these fields should be ignored
+    Angle cameraAngleOfRobot;               // (rad) The current angle of the robot according to the camera
+    bool cameraAngleOfRobotIsSet = 0.0;     // True if the cameraAngleOfRobot is set. If false, these fields should be ignored
     
     // Action related variables
-    double kickSpeed;        // (m/s) [0, 6.5] The target speed of the ball. 0.0 means the robot should not kick
-    bool waitForBall;       // Will make the robot wait with kicking untill it has the ball
-    KickType kickType;      // Defines the type of kicking, either normal(horizontal) or chipping(vertical)
+    double kickSpeed = 0.0;                 // (m/s) [0, 6.5] The target speed of the ball. Speed of <= 0.0 is undefined
+    bool waitForBall = false;               // Will make the robot wait with kicking until it has the ball
+    KickType kickType = KickType::NO_KICK;  // Defines the type of kicking, either normal(horizontal) or chipping(vertical), or no kick
     
-    double dribblerSpeed;    // [0, 1] Speed of the dribbler
+    double dribblerSpeed = 0.0;             // [0, 1] Speed of the dribbler
     
-    bool ignorePacket;  // Robot will ignore packet, but robot will reply with feedback
+    bool ignorePacket = false;              // Robot will ignore packet, but robot will reply with feedback
 } RobotCommand;
 
 /* This object represents robot commands that are sent from AI to RobotHub */

--- a/include/roboteam_utils/RobotCommands.hpp
+++ b/include/roboteam_utils/RobotCommands.hpp
@@ -13,7 +13,7 @@ enum class KickType {
 };
 
 typedef struct RobotCommand {
-    unsigned int id = -1;           // [0,15] The id of robot
+    int id;           // [0,15] The id of robot
     
     // Positioning related variables
     Vector2 velocity;               // (m/s) Target velocity of the robot

--- a/include/roboteam_utils/RobotCommands.hpp
+++ b/include/roboteam_utils/RobotCommands.hpp
@@ -8,7 +8,7 @@
 namespace rtt {
 
 enum class KickType {
-    NORMAL, // Horizontal kicking
+    KICK,   // Horizontal kicking
     CHIP    // Diagonally in the air kicking
 };
 


### PR DESCRIPTION
This PR creates a data object for robot commands in rtt_utils. This is has the following benefits:
- RobotHub and AI do not have to create the same data type of their own
- Rtt_networking can completely abstract proto from robot commands (which is great for many reasons)

Without other PRs, this PR does not make a lot of sense, so check these out:
- [PR in networking](https://github.com/RoboTeamTwente/roboteam_networking/pull/8)
- [PR in AI](https://github.com/RoboTeamTwente/roboteam_ai/pull/1336)
- [PR in RobotHub](https://github.com/RoboTeamTwente/roboteam_robothub/pull/57)