### PR TITLE
Improve fileLogger

### DIFF
--- a/include/roboteam_utils/FileLogger.hpp
+++ b/include/roboteam_utils/FileLogger.hpp
@@ -1,33 +1,23 @@
 #pragma once
 
+#include <fstream>
 #include <string>
-#include <memory>
-#include <mutex>
 
 namespace rtt {
 
-/* A class that makes logging to a file easier and safer.
- * It handles opening and closing, writing and flushing.
+/* A small wrapper for ofstream, useful for logging to files.
+ * It handles opening and closing of files.
  * Will append to previously written text in the file.
  * Throws FailedToOpenFileException if for example the
- * given folder path of the file does not exist. */
-class FileLogger {
+ * given folder path of the file does not exist.
+ * Use the operator<< for writing to the file.
+ * Saves at destruction. Use flush for intermediate saving. */
+class FileLogger : public std::ofstream {
 public:
     // Will create and open the file you specify. Eg. "log/LOG.txt"
     explicit FileLogger(const std::string& filePath);
     // Will close the file
     ~FileLogger();
-
-    // Writes the line and appends with a newline character
-    void writeNewLine(const std::string& line);
-    // Writes the given text to the file
-    void write(const std::string& text);
-    // Synchronizes the file with the internal buffer. Read: saves
-    void flush();
-
-private:
-    std::unique_ptr<std::ofstream> stream;
-    std::mutex streamMutex; // Guards the stream
 };
 
 class FailedToOpenFileException : public std::exception {

--- a/src/utils/FileLogger.cpp
+++ b/src/utils/FileLogger.cpp
@@ -5,31 +5,13 @@
 namespace rtt {
 
 FileLogger::FileLogger(const std::string& path) {
-    this->stream = std::make_unique<std::ofstream>(path.c_str(), std::ios_base::out | std::ios_base::app);
-    if (this->stream == nullptr || !this->stream->is_open()) {
-        throw FailedToOpenFileException("Failed to open log file: '" + path + "'");
-    }
+    this->open(path, std::ios_base::out | std::ios_base::app);
+    if (!this->is_open()) throw FailedToOpenFileException("Failed to open log file: '" + path + "'");
     RTT_DEBUG("Logging to: '", path, "'")
 }
 
 FileLogger::~FileLogger() {
-    if (this->stream != nullptr)
-        this->stream->close();
-}
-
-void FileLogger::writeNewLine(const std::string& line) {
-    std::scoped_lock<std::mutex> lock(this->streamMutex);
-    *this->stream << line << std::endl;
-}
-
-void FileLogger::write(const std::string& text) {
-    std::scoped_lock<std::mutex> lock(this->streamMutex);
-    *this->stream << text;
-}
-
-void FileLogger::flush() {
-    std::scoped_lock<std::mutex> lock(this->streamMutex);
-    this->stream->flush();
+    this->close();
 }
 
 FailedToOpenFileException::FailedToOpenFileException(const std::string& _message) : message(_message){}


### PR DESCRIPTION
This allows the usage of the `<<` operator. Now you can directly write objects like Vector2's to a file. This does remove the `write` and `writeLine` functions

This PR is co-dependent on [the PR in RobotHub](https://github.com/RoboTeamTwente/roboteam_robothub/pull/64)