### PR TITLE
Add kickAtAngle field to robot command

### DIFF
--- a/include/roboteam_utils/RobotCommands.hpp
+++ b/include/roboteam_utils/RobotCommands.hpp
@@ -31,6 +31,7 @@ typedef struct RobotCommand {
     double kickSpeed = 0.0;                 // (m/s) [0, 6.5] The target speed of the ball. Speed of <= 0.0 is undefined
     bool waitForBall = false;               // Will make the robot wait with kicking until it has the ball
     KickType kickType = KickType::NO_KICK;  // Defines the type of kicking, either normal(horizontal) or chipping(vertical), or no kick
+    bool kickAtAngle = false;               // Makes robot kick once it arrives at the specified angle, used in combination with angular velocity
     
     double dribblerSpeed = 0.0;             // [0, 1] Speed of the dribbler
     

--- a/src/utils/RobotCommands.cpp
+++ b/src/utils/RobotCommands.cpp
@@ -27,6 +27,7 @@ bool RobotCommand::operator==(const RobotCommand &other) const {
         && this->kickSpeed == other.kickSpeed
         && this->waitForBall == other.waitForBall
         && this->kickType == other.kickType
+        && this->kickAtAngle == other.kickAtAngle
         && this->dribblerSpeed == other.dribblerSpeed
         && this->ignorePacket == other.ignorePacket;
 }
@@ -43,6 +44,7 @@ std::ostream &RobotCommand::write(std::ostream &os) const {
         << "kickSpeed: " << formatString("%5f", this->kickSpeed) << ", "
         << "waitForBall: " << (this->waitForBall ? " true" : "false") << ", "
         << "kickType: " << kickTypeToString(this->kickType) << ", "
+        << "kickAtAngle: " << this->kickAtAngle << ", "
         << "dribblerSpeed: " << formatString("%5f", this->dribblerSpeed) << ", "
         << "ignorePacket: " << (this->ignorePacket ? " true" : "false")
         << "}";

--- a/test/utils/RobotCommandsTest.cpp
+++ b/test/utils/RobotCommandsTest.cpp
@@ -24,6 +24,7 @@ TEST(RobotCommandsTest, instantiation) {
     ASSERT_DOUBLE_EQ(robotCommand.kickSpeed, 0.0);
     ASSERT_FALSE(robotCommand.waitForBall);
     ASSERT_EQ(robotCommand.kickType, KickType::NO_KICK);
+    ASSERT_FALSE(robotCommand.kickAtAngle);
     ASSERT_DOUBLE_EQ(robotCommand.dribblerSpeed, 0.0);
 
     ASSERT_FALSE(robotCommand.ignorePacket);
@@ -41,6 +42,7 @@ TEST(RobotCommandsTest, equals) {
         .kickSpeed = SimpleRandom::getDouble(0.0, 5.0),
         .waitForBall = SimpleRandom::getBool(),
         .kickType = randomKickType(),
+        .kickAtAngle = SimpleRandom::getBool(),
         .dribblerSpeed = SimpleRandom::getDouble(0.0, 5.0),
         .ignorePacket = SimpleRandom::getBool()
     };


### PR DESCRIPTION
This adds the KickAtAngle field to robot commands.
This will use the set angle to determine when the robot should kick while rotating at the given angular velocity